### PR TITLE
[PSQP-2406] Implementação da persistência local com Room

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
+    id("com.google.devtools.ksp")
 }
 
 android {
@@ -50,6 +51,11 @@ android {
 }
 
 dependencies {
+
+    val room_version = "2.6.1"
+
+    implementation("androidx.room:room-runtime:$room_version")
+    ksp("androidx.room:room-compiler:$room_version")
 
     implementation ("androidx.compose.ui:ui-text-google-fonts:1.6.1")
     implementation ("androidx.constraintlayout:constraintlayout-compose:1.0.1")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,8 @@ dependencies {
 
     implementation("androidx.room:room-runtime:$room_version")
     ksp("androidx.room:room-compiler:$room_version")
+    implementation("androidx.room:room-ktx:$room_version")
+
 
     implementation ("androidx.compose.ui:ui-text-google-fonts:1.6.1")
     implementation ("androidx.constraintlayout:constraintlayout-compose:1.0.1")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,11 +53,14 @@ android {
 dependencies {
 
     val room_version = "2.6.1"
+    val lifecycle_version = "2.8.3"
 
     implementation("androidx.room:room-runtime:$room_version")
     ksp("androidx.room:room-compiler:$room_version")
     implementation("androidx.room:room-ktx:$room_version")
 
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycle_version")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:$lifecycle_version")
 
     implementation ("androidx.compose.ui:ui-text-google-fonts:1.6.1")
     implementation ("androidx.constraintlayout:constraintlayout-compose:1.0.1")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <application
         android:name=".App"
+        android:windowSoftInputMode="adjustResize"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/example/budgetapp/domain/models/expense/Expense.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/models/expense/Expense.kt
@@ -1,8 +1,10 @@
 package com.example.budgetapp.domain.models.expense
 
+import androidx.room.Entity
 import com.example.budgetapp.domain.models.transaction.Transaction
 import java.time.LocalDateTime
 
+@Entity
 open class Expense(
     date: LocalDateTime,
     value: Double,

--- a/app/src/main/java/com/example/budgetapp/domain/models/expense/FixedExpense.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/models/expense/FixedExpense.kt
@@ -1,9 +1,11 @@
 package com.example.budgetapp.domain.models.expense
 
+import androidx.room.Entity
 import com.example.budgetapp.domain.models.transaction.FixedTransaction
 import java.time.LocalDate
 import java.time.LocalDateTime
 
+@Entity
 class FixedExpense(
     date: LocalDateTime,
     value: Double,

--- a/app/src/main/java/com/example/budgetapp/domain/models/income/FixedIncome.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/models/income/FixedIncome.kt
@@ -1,9 +1,11 @@
 package com.example.budgetapp.domain.models.income
 
+import androidx.room.Entity
 import com.example.budgetapp.domain.models.transaction.FixedTransaction
 import java.time.LocalDate
 import java.time.LocalDateTime
 
+@Entity
 class FixedIncome(
     date: LocalDateTime,
     value: Double,

--- a/app/src/main/java/com/example/budgetapp/domain/models/income/Income.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/models/income/Income.kt
@@ -1,8 +1,11 @@
 package com.example.budgetapp.domain.models.income
 
+import androidx.room.Entity
 import com.example.budgetapp.domain.models.transaction.Transaction
 import java.time.LocalDateTime
 
+
+@Entity
 class Income(
     date: LocalDateTime,
     value: Double,

--- a/app/src/main/java/com/example/budgetapp/domain/models/income/Income.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/models/income/Income.kt
@@ -21,4 +21,5 @@ class Income(
     init {
         require(value > 0.0) {"Income requires positive value!"}
     }
+
 }

--- a/app/src/main/java/com/example/budgetapp/domain/models/transaction/FixedTransaction.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/models/transaction/FixedTransaction.kt
@@ -1,12 +1,14 @@
 package com.example.budgetapp.domain.models.transaction
 
 import android.util.Log
+import androidx.room.Entity
 import com.example.budgetapp.domain.models.ICategories
 import com.example.budgetapp.utils.validDayofMonth
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
+@Entity
 open class FixedTransaction<T>(
     date: LocalDateTime,
     value: Double,

--- a/app/src/main/java/com/example/budgetapp/domain/models/transaction/FixedTransaction.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/models/transaction/FixedTransaction.kt
@@ -24,6 +24,18 @@ open class FixedTransaction<T>(
     description = description,
 ) where T: Enum<T>,T: ICategories {
 
+    override fun equals(other: Any?): Boolean {
+        when(other){
+            is FixedTransaction<*> -> {
+                return super.equals(other) &&
+                        other.active == this.active &&
+                        other.endDate?.isEqual(this.endDate) ?: (other.endDate == this.endDate) &&
+                        other.lastDate.isEqual(this.lastDate)
+            }
+            else -> return false
+        }
+    }
+
     private fun findCorrectDate(date: LocalDate): LocalDate{
         return if (date.isBefore(LocalDate.now())) date else date.minusMonths(1)
     }

--- a/app/src/main/java/com/example/budgetapp/domain/models/transaction/Transaction.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/models/transaction/Transaction.kt
@@ -7,18 +7,34 @@ import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.enums.EnumEntries
 
+
 @Entity
 open class Transaction<T> (
     var date: LocalDateTime,
     var value: Double,
     open var category: T,
     var description: String,
-    @PrimaryKey var id: UUID = UUID.randomUUID(),
+    @PrimaryKey(autoGenerate = true)
+    var id: Int? = null,
 )where T: Enum<T>, T : ICategories{
     init {
         require( value != 0.0)
     }
     override fun toString() : String {
         return "${category.displayName} $description"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        when(other){
+            is Transaction<*> -> {
+                return super.equals(other) &&
+                        other.id == this.id &&
+                        other.category == this.category &&
+                        other.date.isEqual(this.date) &&
+                        other.value == this.value &&
+                        other.description.equals(this.description)
+            }
+            else -> return false
+        }
     }
 }

--- a/app/src/main/java/com/example/budgetapp/domain/models/transaction/Transaction.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/models/transaction/Transaction.kt
@@ -1,16 +1,19 @@
 package com.example.budgetapp.domain.models.transaction
 
+import androidx.room.Entity
+import androidx.room.PrimaryKey
 import com.example.budgetapp.domain.models.ICategories
 import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.enums.EnumEntries
 
+@Entity
 open class Transaction<T> (
     var date: LocalDateTime,
     var value: Double,
     open var category: T,
     var description: String,
-    val id: UUID = UUID.randomUUID(),
+    @PrimaryKey var id: UUID = UUID.randomUUID(),
 )where T: Enum<T>, T : ICategories{
     init {
         require( value != 0.0)

--- a/app/src/main/java/com/example/budgetapp/domain/models/transaction/Transaction.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/models/transaction/Transaction.kt
@@ -14,8 +14,8 @@ open class Transaction<T> (
     var value: Double,
     open var category: T,
     var description: String,
-    @PrimaryKey(autoGenerate = true)
-    var id: Int? = null,
+    @PrimaryKey
+    var id: UUID = UUID.randomUUID(),
 )where T: Enum<T>, T : ICategories{
     init {
         require( value != 0.0)

--- a/app/src/main/java/com/example/budgetapp/domain/modules/KoinModules.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/modules/KoinModules.kt
@@ -30,6 +30,7 @@ import org.koin.dsl.module
 fun provideDatabase(context: Context): AppDatabase =
     Room.databaseBuilder(context, AppDatabase::class.java,"appDatabase")
         .allowMainThreadQueries()
+        .fallbackToDestructiveMigration()
         .build()
 
 fun provideIncomeDao(db: AppDatabase): IncomeDao = db.incomeDao()

--- a/app/src/main/java/com/example/budgetapp/domain/modules/KoinModules.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/modules/KoinModules.kt
@@ -1,5 +1,7 @@
 package com.example.budgetapp.domain.modules
 
+import android.content.Context
+import androidx.room.Room
 import com.example.budgetapp.domain.repository_interfaces.IExpenseRepository
 import com.example.budgetapp.domain.repository_interfaces.IFixedExpenseRepository
 import com.example.budgetapp.domain.repository_interfaces.IFixedIncomeRepository
@@ -12,20 +14,38 @@ import com.example.budgetapp.presentation.viewModels.transactionBottomSheet.FInc
 import com.example.budgetapp.presentation.viewModels.home.HomeViewModel
 import com.example.budgetapp.presentation.viewModels.records.RecordsViewModel
 import com.example.budgetapp.presentation.viewModels.transactionBottomSheet.IncomeBottomSheetViewModel
+import com.example.budgetapp.services.dao.expense.ExpenseDao
+import com.example.budgetapp.services.dao.fixedExpense.FixedExpenseDao
+import com.example.budgetapp.services.dao.fixedIncome.FixedIncomeDao
+import com.example.budgetapp.services.dao.income.IncomeDao
+import com.example.budgetapp.services.database.AppDatabase
 import com.example.budgetapp.services.repository.expense.LocalExpenseRepository
 import com.example.budgetapp.services.repository.fixed_expense.LocalFixedExpenseRepository
 import com.example.budgetapp.services.repository.fixed_income.LocalFixedIncomeRepository
 import com.example.budgetapp.services.repository.income.LocalIncomeRepository
+import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
-val homePageModule = module{
+fun provideDatabase(context: Context): AppDatabase =
+    Room.databaseBuilder(context, AppDatabase::class.java,"appDatabase")
+        .allowMainThreadQueries()
+        .build()
 
-    single<IExpenseRepository> {LocalExpenseRepository}
-    single<IFixedExpenseRepository>{LocalFixedExpenseRepository}
-    single<IIncomeRepository> {LocalIncomeRepository}
-    single<IFixedIncomeRepository>{LocalFixedIncomeRepository}
+fun provideIncomeDao(db: AppDatabase): IncomeDao = db.incomeDao()
+fun provideExpenseDao(db: AppDatabase): ExpenseDao = db.expenseDao()
+fun provideFixedExpenseDao(db: AppDatabase): FixedExpenseDao = db.fixedExpenseDao()
+fun provideFixedIncomeDao(db: AppDatabase): FixedIncomeDao = db.fixedIncomeDao()
 
+val DatabaseModule = module {
+    single { provideDatabase(androidContext()) }
+    single { provideIncomeDao(get()) }
+    single { provideExpenseDao(get()) }
+    single { provideFixedExpenseDao(get()) }
+    single { provideFixedIncomeDao(get()) }
+}
+
+val HomePageModule = module{
     viewModel<HomeViewModel> {
         HomeViewModel(get(), get(), get(), get())
     }
@@ -37,53 +57,42 @@ val uiStateModule = module{
 }
 
 val ExpenseBottomSheetModule = module {
-
-    single<IExpenseRepository> {LocalExpenseRepository}
     includes(uiStateModule)
-
     viewModel<ExpenseBottomSheetViewModel>{
         ExpenseBottomSheetViewModel(get(), get(), get())
     }
 }
 
 val IncomeBottomSheetModule = module {
-
-    single<IIncomeRepository> {LocalIncomeRepository}
     includes(uiStateModule)
-
     viewModel<IncomeBottomSheetViewModel>{
         IncomeBottomSheetViewModel(get(), get(), get())
     }
 }
 
 val FixedExpenseBottomSheetModule = module {
-
-    single<IFixedExpenseRepository> {LocalFixedExpenseRepository}
     includes(uiStateModule)
-
     viewModel<FExpenseBottomSheetViewModel>{
         FExpenseBottomSheetViewModel(get(), get(), get())
     }
 }
 
 val FixedIncomeBottomSheetModule = module {
-
-    single<IFixedIncomeRepository> {LocalFixedIncomeRepository}
     includes(uiStateModule)
-
     viewModel<FIncomeBottomSheetViewModel>{
         FIncomeBottomSheetViewModel(get(), get(), get())
     }
 }
 
 val RecordsModule = module {
-
-    single<IExpenseRepository> {LocalExpenseRepository}
-    single<IFixedExpenseRepository>{LocalFixedExpenseRepository}
-    single<IIncomeRepository> {LocalIncomeRepository}
-    single<IFixedIncomeRepository>{LocalFixedIncomeRepository}
-
     viewModel<RecordsViewModel> {
         RecordsViewModel(get(), get(), get(), get())
     }
+}
+
+val RepositoryModule = module {
+    factory<IExpenseRepository> {LocalExpenseRepository(get())}
+    factory<IFixedExpenseRepository>{LocalFixedExpenseRepository(get())}
+    factory<IIncomeRepository> { LocalIncomeRepository(get()) }
+    factory<IFixedIncomeRepository>{LocalFixedIncomeRepository(get())}
 }

--- a/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IExpenseRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IExpenseRepository.kt
@@ -1,12 +1,11 @@
 package com.example.budgetapp.domain.repository_interfaces
 
 import com.example.budgetapp.domain.models.expense.Expense
+import kotlinx.coroutines.flow.Flow
 
 interface IExpenseRepository {
-
-    fun fetchAll():MutableList<Expense>
-    fun addExpense(expense: Expense)
-    fun removeExpense(expense: Expense)
-    fun updateExpense(expense: Expense)
-
+    suspend fun fetchAll(): Flow<List<Expense>>
+    suspend fun addExpense(expense: Expense): Long
+    suspend fun removeExpense(expense: Expense): Int
+    suspend fun updateExpense(expense: Expense): Int
 }

--- a/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IExpenseRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IExpenseRepository.kt
@@ -4,8 +4,8 @@ import com.example.budgetapp.domain.models.expense.Expense
 import kotlinx.coroutines.flow.Flow
 
 interface IExpenseRepository {
-    suspend fun fetchAll(): Flow<List<Expense>>
+    fun fetchAll(): Flow<List<Expense>>
     suspend fun addExpense(expense: Expense): Long
     suspend fun removeExpense(expense: Expense): Int
-    suspend fun updateExpense(expense: Expense): Int
+    suspend fun updateExpense(expense: Expense): Long
 }

--- a/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IFixedExpenseRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IFixedExpenseRepository.kt
@@ -8,4 +8,5 @@ interface IFixedExpenseRepository {
     suspend fun addFixedExpense(fixedExpense: FixedExpense): Long
     suspend fun removeFixedExpense(fixedExpense: FixedExpense): Int
     suspend fun updateFixedExpense(fixedExpense: FixedExpense): Long
+    suspend fun updateFixedExpense(fixedExpenses: List<FixedExpense>): Int
 }

--- a/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IFixedExpenseRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IFixedExpenseRepository.kt
@@ -1,10 +1,11 @@
 package com.example.budgetapp.domain.repository_interfaces
 
 import com.example.budgetapp.domain.models.expense.FixedExpense
+import kotlinx.coroutines.flow.Flow
 
 interface IFixedExpenseRepository {
-    fun fetchAll():MutableList<FixedExpense>
-    fun addFixedExpense(fixedExpense: FixedExpense)
-    fun removeFixedExpense(fixedExpense: FixedExpense)
-    fun updateFixedExpense(fixedExpense: FixedExpense)
+    suspend fun fetchAll(): Flow<List<FixedExpense>>
+    suspend fun addFixedExpense(fixedExpense: FixedExpense): Long
+    suspend fun removeFixedExpense(fixedExpense: FixedExpense): Int
+    suspend fun updateFixedExpense(fixedExpense: FixedExpense): Int
 }

--- a/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IFixedExpenseRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IFixedExpenseRepository.kt
@@ -4,8 +4,8 @@ import com.example.budgetapp.domain.models.expense.FixedExpense
 import kotlinx.coroutines.flow.Flow
 
 interface IFixedExpenseRepository {
-    suspend fun fetchAll(): Flow<List<FixedExpense>>
+    fun fetchAll(): Flow<List<FixedExpense>>
     suspend fun addFixedExpense(fixedExpense: FixedExpense): Long
     suspend fun removeFixedExpense(fixedExpense: FixedExpense): Int
-    suspend fun updateFixedExpense(fixedExpense: FixedExpense): Int
+    suspend fun updateFixedExpense(fixedExpense: FixedExpense): Long
 }

--- a/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IFixedIncomeRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IFixedIncomeRepository.kt
@@ -9,4 +9,5 @@ interface IFixedIncomeRepository {
     suspend fun addFixedIncome(fixedIncome: FixedIncome): Long
     suspend fun removeFixedIncome(fixedIncome: FixedIncome): Int
     suspend fun updateFixedIncome(fixedIncome: FixedIncome): Long
+    suspend fun updateFixedIncome(fixedIncomes: List<FixedIncome>): Int
 }

--- a/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IFixedIncomeRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IFixedIncomeRepository.kt
@@ -1,11 +1,12 @@
 package com.example.budgetapp.domain.repository_interfaces
 
 import com.example.budgetapp.domain.models.income.FixedIncome
+import kotlinx.coroutines.flow.Flow
 
 
 interface IFixedIncomeRepository {
-    fun fetchAll():MutableList<FixedIncome>
-    fun addFixedIncome(fixedIncome: FixedIncome)
-    fun removeFixedIncome(fixedIncome: FixedIncome)
-    fun updateFixedIncome(fixedIncome: FixedIncome)
+    suspend fun fetchAll():Flow<List<FixedIncome>>
+    suspend fun addFixedIncome(fixedIncome: FixedIncome): Long
+    suspend fun removeFixedIncome(fixedIncome: FixedIncome): Int
+    suspend fun updateFixedIncome(fixedIncome: FixedIncome): Int
 }

--- a/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IFixedIncomeRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IFixedIncomeRepository.kt
@@ -5,8 +5,8 @@ import kotlinx.coroutines.flow.Flow
 
 
 interface IFixedIncomeRepository {
-    suspend fun fetchAll():Flow<List<FixedIncome>>
+    fun fetchAll():Flow<List<FixedIncome>>
     suspend fun addFixedIncome(fixedIncome: FixedIncome): Long
     suspend fun removeFixedIncome(fixedIncome: FixedIncome): Int
-    suspend fun updateFixedIncome(fixedIncome: FixedIncome): Int
+    suspend fun updateFixedIncome(fixedIncome: FixedIncome): Long
 }

--- a/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IIncomeRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IIncomeRepository.kt
@@ -4,8 +4,8 @@ import com.example.budgetapp.domain.models.income.Income
 import kotlinx.coroutines.flow.Flow
 
 interface IIncomeRepository {
-    suspend fun fetchAll(): Flow<List<Income>>
+    fun fetchAll(): Flow<List<Income>>
     suspend fun addIncome(income: Income): Long
     suspend fun removeIncome(income: Income): Int
-    suspend fun updateIncome(income: Income): Int
+    suspend fun updateIncome(income: Income): Long
 }

--- a/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IIncomeRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/domain/repository_interfaces/IIncomeRepository.kt
@@ -1,10 +1,11 @@
 package com.example.budgetapp.domain.repository_interfaces
 
 import com.example.budgetapp.domain.models.income.Income
+import kotlinx.coroutines.flow.Flow
 
 interface IIncomeRepository {
-    fun fetchAll():MutableList<Income>
-    fun addIncome(income: Income)
-    fun removeIncome(income: Income)
-    fun updateIncome(income: Income)
+    suspend fun fetchAll(): Flow<List<Income>>
+    suspend fun addIncome(income: Income): Long
+    suspend fun removeIncome(income: Income): Int
+    suspend fun updateIncome(income: Income): Int
 }

--- a/app/src/main/java/com/example/budgetapp/presentation/components/AddExpenseBottomSheet.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/components/AddExpenseBottomSheet.kt
@@ -4,7 +4,9 @@ package com.example.budgetapp.presentation.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -89,6 +91,7 @@ fun AddExpenseBottomSheet(
                 onDismiss()
                 bottomSheetViewModel.clearState()
             },
+            windowInsets = WindowInsets.ime
         ) {
             Text(
                 modifier = modifier.fillMaxWidth(),

--- a/app/src/main/java/com/example/budgetapp/presentation/components/AddFExpenseBottomSheet.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/components/AddFExpenseBottomSheet.kt
@@ -2,7 +2,9 @@ package com.example.budgetapp.presentation.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -81,6 +83,7 @@ fun AddFExpenseBottomSheet(
                 onDismiss()
                 bottomSheetViewModel.clearState()
             },
+            windowInsets = WindowInsets.ime
         ) {
             Text(
                 modifier = modifier.fillMaxWidth(),

--- a/app/src/main/java/com/example/budgetapp/presentation/components/AddFIncomeBottomSheet.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/components/AddFIncomeBottomSheet.kt
@@ -2,7 +2,9 @@ package com.example.budgetapp.presentation.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -82,6 +84,7 @@ fun AddFIncomeBottomSheet(
                 onDismiss()
                 bottomSheetViewModel.clearState()
             },
+            windowInsets = WindowInsets.ime
         ) {
             Text(
                 modifier = modifier.fillMaxWidth(),

--- a/app/src/main/java/com/example/budgetapp/presentation/components/AddIncomeBottomSheet.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/components/AddIncomeBottomSheet.kt
@@ -4,7 +4,9 @@ package com.example.budgetapp.presentation.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -85,6 +87,7 @@ fun AddIncomeBottomSheet(
                 onDismiss()
                 bottomSheetViewModel.clearState()
             },
+            windowInsets = WindowInsets.ime
         ) {
             Text(
                 modifier = modifier.fillMaxWidth(),

--- a/app/src/main/java/com/example/budgetapp/presentation/components/CardSaldo.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/components/CardSaldo.kt
@@ -2,10 +2,13 @@ package com.example.budgetapp.presentation.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
@@ -37,71 +40,200 @@ fun CardSaldo(
     expenseBalance: Double,
     modifier: Modifier = Modifier,
     onReloadClicked: () -> Unit = {},
+    isLoading: Boolean = false
 ) {
     Surface(
         color = Green40,
         modifier = modifier,
         shape = RoundedCornerShape(29.dp)
     ) {
-        Column {
-            Row (modifier = modifier.fillMaxWidth()){
-                Column(
-                    modifier = modifier
-                        .padding(start = 16.dp, end = 16.dp, top = 16.dp)
-                        .weight(1f)
-                ) {
-                    Text(text = stringResource(id = R.string.balance), fontWeight = FontWeight.Bold, fontSize = 20.sp)
-                    Text(
-                        text = formatCurrency(totalBalance),
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 24.sp
-                    )
-                }
-                Column(modifier = modifier
-                    .padding(end = 16.dp, top = 16.dp)
-                ){
-                    Icon(
-                        imageVector = Icons.Filled.Refresh,
-                        contentDescription = stringResource(id = R.string.cd_update),
-                        tint = Color.White,
-                        modifier = Modifier.clickable { onReloadClicked() }
-                    )
-                }
+        if(isLoading) {
+            loadingContent(modifier, onReloadClicked)
+        }else{
+            loadedContent(modifier, totalBalance, onReloadClicked, incomeBalance, expenseBalance)
+        }
+    }
+}
 
-            }
-            Surface(
-                modifier = modifier.fillMaxWidth(),
-                color = Green20,
-                shape = RoundedCornerShape(29.dp)
+@Composable
+private fun loadingContent(modifier: Modifier, onReloadClicked: () -> Unit) {
+    Column {
+        Row(modifier = modifier.fillMaxWidth()) {
+            Column(
+                modifier = modifier
+                    .padding(start = 16.dp, end = 16.dp, top = 16.dp)
+                    .weight(1f)
             ) {
-                Row(
-                    modifier = modifier
-                        .padding(16.dp)
-                        .fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Column {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Icon(
-                                imageVector = Icons.Filled.KeyboardArrowDown,
-                                contentDescription = stringResource(id = R.string.incomes),
-                                tint = Color(0xFF52FF00)
-                            )
-                            Text(stringResource(id = R.string.incomes), fontWeight = FontWeight.Medium, fontSize = 15.sp)
-                        }
-                        Text(formatCurrency(incomeBalance), textAlign = TextAlign.Start, fontSize = 16.sp)
+                Text(
+                    text = stringResource(id = R.string.balance),
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 20.sp
+                )
+                Text(
+                    modifier = Modifier.shimmerEffect(),
+                    text = "R$ 00.000,00",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 24.sp,
+                    color = Color.Transparent
+                )
+            }
+            Column(
+                modifier = modifier
+                    .padding(end = 16.dp, top = 16.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Refresh,
+                    contentDescription = stringResource(id = R.string.cd_update),
+                    tint = Color.White,
+                    modifier = Modifier.clickable { onReloadClicked() }
+                )
+            }
+        }
+        Surface(
+            modifier = modifier.fillMaxWidth(),
+            color = Green20,
+            shape = RoundedCornerShape(29.dp)
+        ) {
+            Row(
+                modifier = modifier
+                    .padding(16.dp)
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Filled.KeyboardArrowDown,
+                            contentDescription = stringResource(id = R.string.incomes),
+                            tint = Color(0xFF52FF00)
+                        )
+                        Text(
+                            stringResource(id = R.string.incomes),
+                            fontWeight = FontWeight.Medium,
+                            fontSize = 15.sp
+                        )
                     }
-                    Column {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Icon(
-                                imageVector = Icons.Filled.KeyboardArrowUp,
-                                contentDescription = stringResource(id = R.string.expenses),
-                                tint = Color(0xFFFF0000)
-                            )
-                            Text(stringResource(id = R.string.expenses), fontWeight = FontWeight.Medium, fontSize = 15.sp)
-                        }
-                        Text(formatCurrency(expenseBalance), textAlign = TextAlign.End, fontSize = 16.sp)
+                    Text(
+                        modifier = Modifier.shimmerEffect(),
+                        text = "R$ 00.000,00",
+                        textAlign = TextAlign.Start,
+                        fontSize = 16.sp,
+                        color = Color.Transparent
+                    )
+                }
+                Column {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Filled.KeyboardArrowUp,
+                            contentDescription = stringResource(id = R.string.expenses),
+                            tint = Color(0xFFFF0000)
+                        )
+                        Text(
+                            stringResource(id = R.string.expenses),
+                            fontWeight = FontWeight.Medium,
+                            fontSize = 15.sp
+                        )
                     }
+                    Text(
+                        modifier = Modifier.shimmerEffect(),
+                        text = "R$ 00.000,00",
+                        textAlign = TextAlign.Start,
+                        fontSize = 16.sp,
+                        color = Color.Transparent
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun loadedContent(
+    modifier: Modifier,
+    totalBalance: Double,
+    onReloadClicked: () -> Unit,
+    incomeBalance: Double,
+    expenseBalance: Double
+) {
+    Column {
+        Row(modifier = modifier.fillMaxWidth()) {
+            Column(
+                modifier = modifier
+                    .padding(start = 16.dp, end = 16.dp, top = 16.dp)
+                    .weight(1f)
+            ) {
+                Text(
+                    text = stringResource(id = R.string.balance),
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 20.sp
+                )
+                Text(
+                    text = formatCurrency(totalBalance),
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 24.sp
+                )
+            }
+            Column(
+                modifier = modifier
+                    .padding(end = 16.dp, top = 16.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Refresh,
+                    contentDescription = stringResource(id = R.string.cd_update),
+                    tint = Color.White,
+                    modifier = Modifier.clickable { onReloadClicked() }
+                )
+            }
+
+        }
+        Surface(
+            modifier = modifier.fillMaxWidth(),
+            color = Green20,
+            shape = RoundedCornerShape(29.dp)
+        ) {
+            Row(
+                modifier = modifier
+                    .padding(16.dp)
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Filled.KeyboardArrowDown,
+                            contentDescription = stringResource(id = R.string.incomes),
+                            tint = Color(0xFF52FF00)
+                        )
+                        Text(
+                            stringResource(id = R.string.incomes),
+                            fontWeight = FontWeight.Medium,
+                            fontSize = 15.sp
+                        )
+                    }
+                    Text(
+                        formatCurrency(incomeBalance),
+                        textAlign = TextAlign.Start,
+                        fontSize = 16.sp
+                    )
+                }
+                Column {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Filled.KeyboardArrowUp,
+                            contentDescription = stringResource(id = R.string.expenses),
+                            tint = Color(0xFFFF0000)
+                        )
+                        Text(
+                            stringResource(id = R.string.expenses),
+                            fontWeight = FontWeight.Medium,
+                            fontSize = 15.sp
+                        )
+                    }
+                    Text(
+                        formatCurrency(expenseBalance),
+                        textAlign = TextAlign.End,
+                        fontSize = 16.sp
+                    )
                 }
             }
         }
@@ -115,7 +247,21 @@ fun cardSaldoPreview() {
         CardSaldo(
             totalBalance = 1500.00,
             expenseBalance = 250.00,
-            incomeBalance = 1750.00
+            incomeBalance = 1750.00,
+            isLoading = false
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 320)
+@Composable
+fun cardSaldoLoadingPreview() {
+    BudgetAppTheme {
+        CardSaldo(
+            totalBalance = 1500.00,
+            expenseBalance = 250.00,
+            incomeBalance = 1750.00,
+            isLoading = true
         )
     }
 }

--- a/app/src/main/java/com/example/budgetapp/presentation/components/FixedTransactionsCard.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/components/FixedTransactionsCard.kt
@@ -143,7 +143,7 @@ fun FixedTransactionsCard(
         }
     }
 }
-
+/*
 @Preview(showBackground = true)
 @Composable
 fun FixedTransactionCardPreview(){
@@ -152,4 +152,4 @@ fun FixedTransactionCardPreview(){
             cardName = "Receitas Fixas",
             transactions = LocalFixedIncomeRepository.fetchAll() as List<FixedTransaction<*>>)
     }
-}
+}*/

--- a/app/src/main/java/com/example/budgetapp/presentation/components/FixedTransactionsCard.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/components/FixedTransactionsCard.kt
@@ -45,8 +45,11 @@ import androidx.compose.ui.unit.sp
 import com.example.budgetapp.R
 import com.example.budgetapp.domain.models.transaction.FixedTransaction
 import com.example.budgetapp.presentation.ui.theme.BudgetAppTheme
+import com.example.budgetapp.services.dao.fixedIncome.FixedIncomeDao
+import com.example.budgetapp.services.dao.fixedIncome.FixedIncomeDao_Impl
 import com.example.budgetapp.services.repository.fixed_income.LocalFixedIncomeRepository
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun FixedTransactionsCard(
     cardName: String,
@@ -54,7 +57,8 @@ fun FixedTransactionsCard(
     modifier: Modifier = Modifier,
     expanded: Boolean = true,
     onNewTransactionClicked: () -> Unit = {},
-    onSeeMoreClicked: () -> Unit = {}
+    onSeeMoreClicked: () -> Unit = {},
+    isLoading: Boolean = false
 ){
 
     var expanded by rememberSaveable { mutableStateOf(expanded) }
@@ -111,25 +115,38 @@ fun FixedTransactionsCard(
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     Divider()
-                    if(transactions.isNotEmpty()) {
+                    if(isLoading){
                         LazyColumn(modifier = modifier.height(110.dp)) {
-                            item {
-                                TransactionDateHeader(
-                                    date = null,
-                                    total = transactions.sumOf { it.value })
+                            stickyHeader {
+                                ShimmerTransactionDateHeader()
                             }
-                            items(transactions.sortedBy { it.date }) { transaction ->
-                                ItemTransactionsCard(transaction = transaction)
+                            items(3) {
+                                ShimmerItemTransactionsCard()
                                 Divider()
                             }
                         }
-                    }else{
-                        Text(
-                            modifier = modifier.clickable { onSeeMoreClicked() },
-                            text = stringResource(R.string.nothing_found),
-                            color = Color.Gray,
-                            textAlign = TextAlign.Center)
-                        Divider()
+                    }else {
+                        if (transactions.isNotEmpty()) {
+                            LazyColumn(modifier = modifier.height(110.dp)) {
+                                item {
+                                    TransactionDateHeader(
+                                        date = null,
+                                        total = transactions.sumOf { it.value })
+                                }
+                                items(transactions.sortedBy { it.date }) { transaction ->
+                                    ItemTransactionsCard(transaction = transaction)
+                                    Divider()
+                                }
+                            }
+                        } else {
+                            Text(
+                                modifier = modifier.clickable { onNewTransactionClicked() },
+                                text = stringResource(R.string.nothing_found),
+                                color = Color.Gray,
+                                textAlign = TextAlign.Center
+                            )
+                            Divider()
+                        }
                     }
 
                     Text(
@@ -143,13 +160,13 @@ fun FixedTransactionsCard(
         }
     }
 }
-/*
+
 @Preview(showBackground = true)
 @Composable
 fun FixedTransactionCardPreview(){
     BudgetAppTheme {
         FixedTransactionsCard(
             cardName = "Receitas Fixas",
-            transactions = LocalFixedIncomeRepository.fetchAll() as List<FixedTransaction<*>>)
+            transactions = FixedIncomeDao_Impl.getRequiredConverters() as List<FixedTransaction<*>>)
     }
-}*/
+}

--- a/app/src/main/java/com/example/budgetapp/presentation/components/ItemTransactionsCard.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/components/ItemTransactionsCard.kt
@@ -7,11 +7,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
+import com.example.budgetapp.domain.models.expense.Expense
+import com.example.budgetapp.domain.models.expense.ExpenseCategory
 import com.example.budgetapp.domain.models.transaction.Transaction
+import com.example.budgetapp.presentation.ui.theme.BudgetAppTheme
 import com.example.budgetapp.utils.formatCurrency
+import java.time.LocalDateTime
 
 @Composable
 fun ItemTransactionsCard(transaction: Transaction<*>, modifier: Modifier = Modifier){
@@ -44,5 +49,49 @@ fun ItemTransactionsCard(transaction: Transaction<*>, modifier: Modifier = Modif
             fontSize = 12.sp,
             text = transaction.description
         )
+    }
+}
+
+@Composable
+fun ShimmerItemTransactionsCard(modifier: Modifier = Modifier){
+    ConstraintLayout(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(2.dp),
+    ) {
+        val (desc, valor) = createRefs()
+        Text(
+            modifier = modifier
+                .shimmerEffect()
+                .constrainAs(valor) {
+                    end.linkTo(parent.end)
+                    centerVerticallyTo(parent)
+                },
+            color = Color.Transparent,
+            fontWeight = FontWeight.Normal,
+            fontSize = 12.sp,
+            text = "R$ 00000,00"
+        )
+        Text(
+            modifier = modifier
+                .shimmerEffect()
+                .constrainAs(desc) {
+                    start.linkTo(parent.start)
+                    centerVerticallyTo(parent)
+                },
+            color = Color.Transparent,
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 12.sp,
+            text = "Description PlaceHolder"
+        )
+    }
+}
+
+@Preview
+@Composable
+fun PreviewItemTransaction(){
+    BudgetAppTheme {
+        ShimmerItemTransactionsCard()
+
     }
 }

--- a/app/src/main/java/com/example/budgetapp/presentation/components/ShimmerEffect.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/components/ShimmerEffect.kt
@@ -37,9 +37,9 @@ fun Modifier.shimmerEffect(): Modifier = composed {
     background(
         brush = Brush.linearGradient(
             colors = listOf(
-                Color(0x65E2E2E2),
-                Color(0xCBAFAFAF),
-                Color(0x65E2E2E2),
+                Color(0xCDE2E2E2),
+                Color(0xFFAFAFAF),
+                Color(0xCDE2E2E2),
             ),
             start = Offset(startOffsetX, 0f),
             end = Offset(startOffsetX + size.width.toFloat(), size.height.toFloat())

--- a/app/src/main/java/com/example/budgetapp/presentation/components/ShimmerEffect.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/components/ShimmerEffect.kt
@@ -1,0 +1,51 @@
+package com.example.budgetapp.presentation.components
+
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.unit.IntSize
+
+fun Modifier.shimmerEffect(): Modifier = composed {
+    var size by remember {
+        mutableStateOf(IntSize.Zero)
+    }
+
+    val transition = rememberInfiniteTransition()
+    val startOffsetX by transition.animateFloat(
+        initialValue = -2 * size.width.toFloat(),
+        targetValue = 2 * size.width.toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = 1000
+            )
+        ),
+        label = "Shimmer Effect"
+    )
+
+    background(
+        brush = Brush.linearGradient(
+            colors = listOf(
+                Color(0x65E2E2E2),
+                Color(0xCBAFAFAF),
+                Color(0x65E2E2E2),
+            ),
+            start = Offset(startOffsetX, 0f),
+            end = Offset(startOffsetX + size.width.toFloat(), size.height.toFloat())
+        )
+    )
+        .onGloballyPositioned {
+            size = it.size
+        }
+}

--- a/app/src/main/java/com/example/budgetapp/presentation/components/TransactionDateHeader.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/components/TransactionDateHeader.kt
@@ -10,10 +10,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.example.budgetapp.R
+import com.example.budgetapp.presentation.ui.theme.BudgetAppTheme
 import com.example.budgetapp.utils.formatCurrency
 import com.example.budgetapp.utils.toFormattedDate
 import java.time.LocalDate
@@ -68,4 +70,52 @@ fun TransactionDateHeader(
     }
     Divider(color = Color.Black)
 }
+
+@Composable
+fun ShimmerTransactionDateHeader(
+    modifier: Modifier = Modifier
+){
+    Surface(modifier = modifier.fillMaxWidth()) {
+        ConstraintLayout(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(2.dp),
+        ) {
+            val (data, valor) = createRefs()
+
+            Text(
+                modifier = modifier
+                    .shimmerEffect()
+                    .constrainAs(valor) {
+                        end.linkTo(parent.end)
+                        centerVerticallyTo(parent)
+                    },
+                color = Color.Transparent,
+                fontWeight = FontWeight.Bold,
+                fontSize = 12.sp,
+                text = "R$ 00.000,00"
+            )
+
+            Text(
+                modifier = modifier
+                    .shimmerEffect()
+                    .constrainAs(data) { centerTo(parent) },
+                color = Color.Transparent,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 12.sp,
+                text = "PlaceHolder Title"
+            )
+        }
+    }
+    Divider(color = Color.Black)
+}
+
+@Preview
+@Composable
+fun PreviewTransactionHeader(){
+    BudgetAppTheme {
+        ShimmerTransactionDateHeader()
+    }
+}
+
 

--- a/app/src/main/java/com/example/budgetapp/presentation/components/TransactionRecords.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/components/TransactionRecords.kt
@@ -229,8 +229,7 @@ fun PreviewRecordCard(){
             modifier = Modifier,
             transactions = emptyList(),
             onDelete = {
-                //LocalIncomeRepository.removeIncome(it as Income)
-                //transactions = LocalIncomeRepository.fetchAll()
+
             },
             isLoading = true
         )

--- a/app/src/main/java/com/example/budgetapp/presentation/components/TransactionRecords.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/components/TransactionRecords.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -66,7 +67,8 @@ fun RecordCard(
     onDelete: (Transaction<*>) -> Unit = {},
     modifier: Modifier = Modifier,
     onNewTransactionClicked: ()->Unit = { },
-    showAdd: Boolean = true
+    showAdd: Boolean = true,
+    isLoading: Boolean = false
 ){
     val dropMenuOptions = stringArrayResource(R.array.records_drop_menu_options)
 
@@ -128,46 +130,61 @@ fun RecordCard(
                 )
             }
             Divider()
-            LazyColumn(
-                modifier = Modifier
-            ) {
-                if (transactions.isNotEmpty()) {
-                    filters.forEach { (_, items) ->
+            if(isLoading){
+                LazyColumn(modifier = Modifier) {
+                    stickyHeader {
+                        ShimmerTransactionDateHeader()
+                    }
+                    items(3) {
+                        ShimmerItemTransactionsCard(
+                            modifier = Modifier.padding(vertical = 5.dp)
+                        )
+                        Divider()
+                    }
+                }
+            }else{
+                LazyColumn(
+                    modifier = Modifier
+                ) {
+                    if (transactions.isNotEmpty()) {
+                        filters.forEach { (_, items) ->
 
-                        stickyHeader {
-                            TransactionDateHeader(
-                                total = items.sumOf { it.value },
-                                title = if(filterBy) toFormattedMonthYear(items.first().date.toLocalDate())
-                                            else (items.first().category as ICategories).asString()
-                            )
-                        }
-                        items(
-                            items = items,
-                            key = { it.id!! }
-                        ) { item ->
-                            SwipeToDeleteContainer<Transaction<*>>(
-                                item = item,
-                                onDelete = { onDelete(it) },
-                                content = {
-                                    Surface(
-                                    ) {
-                                        ItemTransactionsCard(
-                                            transaction = it,
-                                            modifier = Modifier.padding(vertical = 5.dp)
-                                        )
+                            stickyHeader {
+                                TransactionDateHeader(
+                                    total = items.sumOf { it.value },
+                                    title = if (filterBy) toFormattedMonthYear(items.first().date.toLocalDate())
+                                    else (items.first().category as ICategories).asString()
+                                )
+                            }
+                            items(
+                                items = items,
+                                key = { it.id }
+                            ) { item ->
+                                SwipeToDeleteContainer<Transaction<*>>(
+                                    item = item,
+                                    onDelete = { onDelete(it) },
+                                    content = {
+                                        Surface(
+                                        ) {
+                                            ItemTransactionsCard(
+                                                transaction = it,
+                                                modifier = Modifier.padding(vertical = 5.dp)
+                                            )
+                                        }
                                     }
-                                }
+                                )
+                                Divider()
+                            }
+                        }
+                    } else {
+                        item() {
+                            Text(
+                                text = stringResource(R.string.nothing_found),
+                                color = Color.Gray,
+                                textAlign = TextAlign.Center
                             )
                             Divider()
                         }
-                    }
-                } else {
-                    item(){
-                        Text(
-                            text = stringResource(R.string.nothing_found),
-                            color = Color.Gray,
-                            textAlign = TextAlign.Center)
-                        Divider()
                     }
                 }
             }
@@ -202,23 +219,20 @@ fun DeleteBackground(
         )
     }
 }
-/*
+
 @Preview(showBackground = true)
 @Composable
 fun PreviewRecordCard(){
     BudgetAppTheme {
 
-        var transactions by remember {
-            mutableStateOf(LocalIncomeRepository().fetchAll())
-        }
-
         RecordCard(
             modifier = Modifier,
-            transactions = transactions,
+            transactions = emptyList(),
             onDelete = {
-                LocalIncomeRepository.removeIncome(it as Income)
-                transactions = LocalIncomeRepository.fetchAll()
-            }
+                //LocalIncomeRepository.removeIncome(it as Income)
+                //transactions = LocalIncomeRepository.fetchAll()
+            },
+            isLoading = true
         )
     }
-}*/
+}

--- a/app/src/main/java/com/example/budgetapp/presentation/components/TransactionRecords.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/components/TransactionRecords.kt
@@ -54,6 +54,7 @@ import com.example.budgetapp.domain.models.transaction.Transaction
 import com.example.budgetapp.presentation.ui.theme.BudgetAppTheme
 import com.example.budgetapp.services.repository.income.LocalIncomeRepository
 import androidx.compose.ui.res.stringResource
+import com.example.budgetapp.services.dao.income.IncomeDao
 import com.example.budgetapp.utils.sortByCategory
 import com.example.budgetapp.utils.sortByMonth
 import com.example.budgetapp.utils.toFormattedMonthYear
@@ -201,14 +202,14 @@ fun DeleteBackground(
         )
     }
 }
-
+/*
 @Preview(showBackground = true)
 @Composable
 fun PreviewRecordCard(){
     BudgetAppTheme {
 
         var transactions by remember {
-            mutableStateOf(LocalIncomeRepository.fetchAll())
+            mutableStateOf(LocalIncomeRepository().fetchAll())
         }
 
         RecordCard(
@@ -220,4 +221,4 @@ fun PreviewRecordCard(){
             }
         )
     }
-}
+}*/

--- a/app/src/main/java/com/example/budgetapp/presentation/components/TransactionRecords.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/components/TransactionRecords.kt
@@ -143,7 +143,7 @@ fun RecordCard(
                         }
                         items(
                             items = items,
-                            key = { it.id }
+                            key = { it.id!! }
                         ) { item ->
                             SwipeToDeleteContainer<Transaction<*>>(
                                 item = item,

--- a/app/src/main/java/com/example/budgetapp/presentation/components/TransactionsCard.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/components/TransactionsCard.kt
@@ -148,7 +148,7 @@ fun TransactionsCard(
         }
     }
 }
-
+/*
 @Preview(showBackground = true)
 @Composable
 fun TransactionCardPreview(){
@@ -157,4 +157,4 @@ fun TransactionCardPreview(){
             cardName = "Receitas",
             transactions = LocalIncomeRepository.fetchAll() as List<Transaction<*>>)
     }
-}
+}*/

--- a/app/src/main/java/com/example/budgetapp/presentation/components/TransactionsCard.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/components/TransactionsCard.kt
@@ -46,6 +46,7 @@ import com.example.budgetapp.R
 import com.example.budgetapp.domain.models.transaction.Transaction
 import com.example.budgetapp.services.repository.income.LocalIncomeRepository
 import com.example.budgetapp.presentation.ui.theme.BudgetAppTheme
+import com.example.budgetapp.services.dao.income.IncomeDao_Impl
 import com.example.budgetapp.utils.sortByDay
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -56,7 +57,8 @@ fun TransactionsCard(
     modifier: Modifier = Modifier,
     expanded: Boolean = true,
     onNewTransactionClicked: () -> Unit = {},
-    onSeeMoreClicked: () -> Unit = {}
+    onSeeMoreClicked: () -> Unit = {},
+    isLoading: Boolean = false
 ){
 
     var expanded by rememberSaveable { mutableStateOf(expanded) }
@@ -113,30 +115,42 @@ fun TransactionsCard(
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     Divider()
-                    if(transactions.isNotEmpty()) {
+                    if(isLoading){
                         LazyColumn(modifier = modifier.height(110.dp)) {
-                            sortByDay(transactions).forEach {(_, items) ->
-
-                                stickyHeader {
-                                    TransactionDateHeader(
-                                        date = items.first().date.toLocalDate(),
-                                        total = items.sumOf { it.value })
-                                }
-                                items(items.sortedBy { it.date }) { transaction ->
-                                    ItemTransactionsCard(
-                                        transaction = transaction,
-                                    )
-                                    Divider()
-                                }
+                            stickyHeader {
+                                ShimmerTransactionDateHeader()
+                            }
+                            items(3) {
+                                ShimmerItemTransactionsCard()
+                                Divider()
                             }
                         }
                     }else{
-                        Text(
-                            modifier = modifier.clickable { onNewTransactionClicked() },
-                            text = stringResource(R.string.nothing_found),
-                            color = Color.Gray,
-                            textAlign = TextAlign.Center)
-                        Divider()
+                        if(transactions.isNotEmpty()) {
+                            LazyColumn(modifier = modifier.height(110.dp)) {
+                                sortByDay(transactions).forEach {(_, items) ->
+
+                                    stickyHeader {
+                                        TransactionDateHeader(
+                                            date = items.first().date.toLocalDate(),
+                                            total = items.sumOf { it.value })
+                                    }
+                                    items(items.sortedBy { it.date }) { transaction ->
+                                        ItemTransactionsCard(
+                                            transaction = transaction,
+                                        )
+                                        Divider()
+                                    }
+                                }
+                            }
+                        }else{
+                            Text(
+                                modifier = modifier.clickable { onNewTransactionClicked() },
+                                text = stringResource(R.string.nothing_found),
+                                color = Color.Gray,
+                                textAlign = TextAlign.Center)
+                            Divider()
+                        }
                     }
                     Text(
                         modifier = modifier.clickable { onSeeMoreClicked() },
@@ -148,13 +162,24 @@ fun TransactionsCard(
         }
     }
 }
-/*
+
 @Preview(showBackground = true)
 @Composable
 fun TransactionCardPreview(){
     BudgetAppTheme {
         TransactionsCard(
             cardName = "Receitas",
-            transactions = LocalIncomeRepository.fetchAll() as List<Transaction<*>>)
+            transactions = IncomeDao_Impl.getRequiredConverters() as List<Transaction<*>>)
     }
-}*/
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ShimmerTransactionCardPreview(){
+    BudgetAppTheme {
+        TransactionsCard(
+            cardName = "Receitas",
+            transactions = IncomeDao_Impl.getRequiredConverters() as List<Transaction<*>>,
+            isLoading = true)
+    }
+}

--- a/app/src/main/java/com/example/budgetapp/presentation/graphs/RecordNavigationGraph.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/graphs/RecordNavigationGraph.kt
@@ -3,6 +3,7 @@ package com.example.budgetapp.presentation.graphs
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavArgument
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHost
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -51,7 +52,7 @@ fun RecordNavigationGraph(
                     isFixed = isFixed,
                     viewModel = recordsViewModel,
                     onReturnClicked = {
-                        parentNav.navigate(Graph.MAIN)
+                        parentNav.popBackStack()
                     }
                 )
                 isFixed = false
@@ -62,7 +63,7 @@ fun RecordNavigationGraph(
                     isFixed = isFixed,
                     viewModel = recordsViewModel,
                     onReturnClicked = {
-                        parentNav.navigate(Graph.MAIN)
+                        parentNav.popBackStack()
                     }
                 )
                 isFixed = false

--- a/app/src/main/java/com/example/budgetapp/presentation/viewModels/home/HomeUiState.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/viewModels/home/HomeUiState.kt
@@ -1,17 +1,22 @@
 package com.example.budgetapp.presentation.viewModels.home
 
+import androidx.compose.runtime.mutableStateOf
 import com.example.budgetapp.domain.models.expense.Expense
 import com.example.budgetapp.domain.models.expense.FixedExpense
 import com.example.budgetapp.domain.models.income.FixedIncome
 import com.example.budgetapp.domain.models.income.Income
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 
 data class HomeUiState(
-    val expenses: MutableList<Expense> = mutableListOf(),
-    val incomes: MutableList<Income> = mutableListOf(),
-    val fixedExpense: MutableList<FixedExpense> = mutableListOf(),
-    val fixedIncome: MutableList<FixedIncome> = mutableListOf(),
+    val expenses: List<Expense> = emptyList(),
+    val incomes: List<Income> = emptyList(),
+    val fixedExpense: List<FixedExpense> = emptyList(),
+    val fixedIncome: List<FixedIncome> = emptyList(),
     val userName: String = "",
     val balance: Double = 0.0,
     val incomeBalance: Double = 0.0,
     val expenseBalance: Double = 0.0,
+    val isLoading: Boolean = false,
+    val errorMsg: String? = null
 )

--- a/app/src/main/java/com/example/budgetapp/presentation/viewModels/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/viewModels/home/HomeViewModel.kt
@@ -91,7 +91,6 @@ class HomeViewModel(
             }.distinctUntilChanged().collectLatest{
                 checkDueTransactions(it)
             }
-
     }
 
 

--- a/app/src/main/java/com/example/budgetapp/presentation/viewModels/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/viewModels/home/HomeViewModel.kt
@@ -1,7 +1,6 @@
 package com.example.budgetapp.presentation.viewModels.home
 
 
-import androidx.compose.runtime.collectAsState
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.budgetapp.domain.models.expense.Expense
@@ -13,17 +12,31 @@ import com.example.budgetapp.domain.repository_interfaces.IExpenseRepository
 import com.example.budgetapp.domain.repository_interfaces.IFixedExpenseRepository
 import com.example.budgetapp.domain.repository_interfaces.IFixedIncomeRepository
 import com.example.budgetapp.domain.repository_interfaces.IIncomeRepository
-import com.example.budgetapp.services.repository.fixed_expense.LocalFixedExpenseRepository
-import com.example.budgetapp.services.repository.fixed_income.LocalFixedIncomeRepository
 import com.example.budgetapp.utils.validDayofMonth
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.produce
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import java.time.LocalTime
-import kotlin.math.exp
 
 class HomeViewModel(
     private val expenseRepository: IExpenseRepository,
@@ -38,21 +51,47 @@ class HomeViewModel(
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
     init {
-        startObserver()
+        observeTransactions()
+        observeFixedTransaction()
     }
 
-    fun startObserver(){
-        viewModelScope.launch{
+    fun updateAll(){
+        viewModelScope.launch {
+            fixedExpenseRepository.fetchAll().first{checkDueTransactions(it); true}
+            //checkDueTransactions(fixedExpenseRepository.fetchAll().single())
+        }
+    }
+
+    private fun observeFixedTransaction(){
+        viewModelScope.launch {
+            fixedIncomeRepository.fetchAll().collect(){
+                checkDueTransactions(it)
+            }
+        }
+
+        viewModelScope.launch {
+            fixedExpenseRepository.fetchAll().collect(){
+                println(it)
+                checkDueTransactions(it)
+            }
+        }
+    }
+
+    fun observeTransactions(){
+         viewModelScope.launch{
             combine(
                 incomeRepository.fetchAll(),
                 expenseRepository.fetchAll(),
-
+                fixedIncomeRepository.fetchAll(),
+                fixedExpenseRepository.fetchAll()
             ){
-                incomes, expenses ->
+                incomes, expenses, fixedIncome, fixedExpense ->
 
                 HomeUiState(
                     expenses = expenses,
                     incomes = incomes,
+                    fixedExpense = fixedExpense,
+                    fixedIncome = fixedIncome,
                     balance = getTotalBalance(incomes, expenses),
                     incomeBalance = getIncomeBalance(incomes),
                     expenseBalance = getExpenseBalance(expenses),
@@ -66,44 +105,50 @@ class HomeViewModel(
             }
         }
     }
+
     private fun checkDueTransactions(fixedTransactions: List<FixedTransaction<*>>){
-        fixedTransactions.forEach(){ transaction ->
+        viewModelScope.launch {
+            fixedTransactions.forEach() { transaction ->
+                val delayedMonths = transaction.isDue()
+                if (delayedMonths > 0) {
+                    val curTime = LocalTime.now()
+                    for (i in 1..delayedMonths) {
 
-            val delayedMonths = transaction.isDue()
+                        var date = transaction.lastDate
+                            .plusMonths(1)
+                            .withDayOfMonth(
+                                validDayofMonth(
+                                    transaction.date.dayOfMonth,
+                                    transaction.lastDate
+                                )
+                            );
 
-            if(delayedMonths > 0){
-                val curTime = LocalTime.now()
-                for( i in 1..delayedMonths){
-
-                    var date = transaction.lastDate
-                        .plusMonths(1)
-                        .withDayOfMonth(validDayofMonth(transaction.date.dayOfMonth, transaction.lastDate ));
-
-                    when(transaction) {
-                        is FixedExpense -> expenseRepository.addExpense(
-                            Expense(
-                                date = date.atTime(curTime),
-                                value = transaction.value,
-                                category = transaction.category,
-                                description = transaction.description
+                        when (transaction) {
+                            is FixedExpense -> expenseRepository.addExpense(
+                                Expense(
+                                    date = date.atTime(curTime),
+                                    value = transaction.value,
+                                    category = transaction.category,
+                                    description = transaction.description
+                                )
                             )
-                        )
 
-                        is FixedIncome -> incomeRepository.addIncome(
-                            Income(
-                                date = date.atTime(curTime),
-                                value = transaction.value,
-                                category = transaction.category,
-                                description = transaction.description
+                            is FixedIncome -> incomeRepository.addIncome(
+                                Income(
+                                    date = date.atTime(curTime),
+                                    value = transaction.value,
+                                    category = transaction.category,
+                                    description = transaction.description
+                                )
                             )
-                        )
+                        }
+                        transaction.lastDate = date
+
                     }
-                    transaction.lastDate = date
-
-                }
-                when(transaction) {
-                    is FixedExpense -> fixedExpenseRepository.updateFixedExpense(transaction)
-                    is FixedIncome -> fixedIncomeRepository.updateFixedIncome(transaction)
+                    when (transaction) {
+                        is FixedExpense -> fixedExpenseRepository.updateFixedExpense(transaction)
+                        is FixedIncome -> fixedIncomeRepository.updateFixedIncome(transaction)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/budgetapp/presentation/viewModels/records/RecordsUiState.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/viewModels/records/RecordsUiState.kt
@@ -10,4 +10,6 @@ class RecordsUiState(
     val incomes: List<Income> = listOf(),
     val fixedExpense: List<FixedExpense> = listOf(),
     val fixedIncome: List<FixedIncome> = listOf(),
+    val isLoading: Boolean = false,
+    val errorMsg: String? = null
 )

--- a/app/src/main/java/com/example/budgetapp/presentation/viewModels/records/RecordsUiState.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/viewModels/records/RecordsUiState.kt
@@ -5,7 +5,7 @@ import com.example.budgetapp.domain.models.expense.FixedExpense
 import com.example.budgetapp.domain.models.income.FixedIncome
 import com.example.budgetapp.domain.models.income.Income
 
-class RecordsUiState(
+data class RecordsUiState(
     val expenses: List<Expense> = listOf(),
     val incomes: List<Income> = listOf(),
     val fixedExpense: List<FixedExpense> = listOf(),

--- a/app/src/main/java/com/example/budgetapp/presentation/viewModels/records/RecordsViewModel.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/viewModels/records/RecordsViewModel.kt
@@ -1,6 +1,7 @@
 package com.example.budgetapp.presentation.viewModels.records
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.budgetapp.domain.models.expense.Expense
 import com.example.budgetapp.domain.models.expense.FixedExpense
 import com.example.budgetapp.domain.models.income.FixedIncome
@@ -10,24 +11,22 @@ import com.example.budgetapp.domain.repository_interfaces.IExpenseRepository
 import com.example.budgetapp.domain.repository_interfaces.IFixedExpenseRepository
 import com.example.budgetapp.domain.repository_interfaces.IFixedIncomeRepository
 import com.example.budgetapp.domain.repository_interfaces.IIncomeRepository
+import com.example.budgetapp.presentation.viewModels.home.HomeUiState
 import com.example.budgetapp.services.repository.fixed_expense.LocalFixedExpenseRepository
 import com.example.budgetapp.services.repository.fixed_income.LocalFixedIncomeRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
 
 class RecordsViewModel(
     private val expenseRepository: IExpenseRepository,
     private val incomeRepository: IIncomeRepository,
-    private val fixedExpenseRepository: IFixedExpenseRepository = LocalFixedExpenseRepository,
-    private val fixedIncomeRepository: IFixedIncomeRepository = LocalFixedIncomeRepository,
+    private val fixedExpenseRepository: IFixedExpenseRepository,
+    private val fixedIncomeRepository: IFixedIncomeRepository,
 ): ViewModel() {
-
-    private var _expenses = mutableListOf<Expense>()
-    private var _incomes = mutableListOf<Income>()
-
-    private var _fixedIncomes = mutableListOf<FixedIncome>()
-    private var _fixedExpenses = mutableListOf<FixedExpense>()
 
     private val _uiState = MutableStateFlow(RecordsUiState())
     val uiState: StateFlow<RecordsUiState> = _uiState.asStateFlow()
@@ -36,33 +35,42 @@ class RecordsViewModel(
         updateAll()
     }
 
-    private fun fetchData(){
-        _expenses = expenseRepository.fetchAll()
-        _incomes = incomeRepository.fetchAll()
-        _fixedExpenses = fixedExpenseRepository.fetchAll()
-        _fixedIncomes = fixedIncomeRepository.fetchAll()
-    }
+    fun loadObserver(){
+        viewModelScope.launch{
+            combine(
+                incomeRepository.fetchAll(),
+                expenseRepository.fetchAll(),
+                fixedIncomeRepository.fetchAll(),
+                fixedExpenseRepository.fetchAll()
+            ){incomes, expenses, fixedIncome, fixedExpense ->
 
-    private fun updateState(){
-        _uiState.value = RecordsUiState(
-            expenses = _expenses,
-            incomes = _incomes,
-            fixedExpense = _fixedExpenses,
-            fixedIncome = _fixedIncomes,
-        )
+                RecordsUiState(
+                    expenses = expenses,
+                    incomes = incomes,
+                    fixedExpense = fixedExpense,
+                    fixedIncome = fixedIncome,
+                )
+
+            }.catch {
+                _uiState.value = RecordsUiState(errorMsg = it.message)
+            }.collect{
+                _uiState.value = it
+            }
+        }
     }
 
     fun updateAll(){
-        fetchData()
-        updateState()
+        loadObserver()
     }
 
     fun removeTransaction(transaction: Transaction<*>){
-        when(transaction){
-            is Income -> incomeRepository.removeIncome(transaction)
-            is Expense -> expenseRepository.removeExpense(transaction)
-            is FixedExpense -> fixedExpenseRepository.removeFixedExpense(transaction)
-            is FixedIncome -> fixedIncomeRepository.removeFixedIncome(transaction)
+        viewModelScope.launch {
+            when (transaction) {
+                is Income -> incomeRepository.removeIncome(transaction)
+                is Expense -> expenseRepository.removeExpense(transaction)
+                is FixedExpense -> fixedExpenseRepository.removeFixedExpense(transaction)
+                is FixedIncome -> fixedIncomeRepository.removeFixedIncome(transaction)
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/budgetapp/presentation/viewModels/records/RecordsViewModel.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/viewModels/records/RecordsViewModel.kt
@@ -10,17 +10,15 @@ import com.example.budgetapp.domain.repository_interfaces.IExpenseRepository
 import com.example.budgetapp.domain.repository_interfaces.IFixedExpenseRepository
 import com.example.budgetapp.domain.repository_interfaces.IFixedIncomeRepository
 import com.example.budgetapp.domain.repository_interfaces.IIncomeRepository
-import com.example.budgetapp.services.repository.expense.LocalExpenseRepository
 import com.example.budgetapp.services.repository.fixed_expense.LocalFixedExpenseRepository
 import com.example.budgetapp.services.repository.fixed_income.LocalFixedIncomeRepository
-import com.example.budgetapp.services.repository.income.LocalIncomeRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 class RecordsViewModel(
-    private val expenseRepository: IExpenseRepository = LocalExpenseRepository,
-    private val incomeRepository: IIncomeRepository = LocalIncomeRepository,
+    private val expenseRepository: IExpenseRepository,
+    private val incomeRepository: IIncomeRepository,
     private val fixedExpenseRepository: IFixedExpenseRepository = LocalFixedExpenseRepository,
     private val fixedIncomeRepository: IFixedIncomeRepository = LocalFixedIncomeRepository,
 ): ViewModel() {

--- a/app/src/main/java/com/example/budgetapp/presentation/viewModels/transactionBottomSheet/ExpenseBottomSheetViewModel.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/viewModels/transactionBottomSheet/ExpenseBottomSheetViewModel.kt
@@ -2,6 +2,7 @@ package com.example.budgetapp.presentation.viewModels.transactionBottomSheet
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.budgetapp.domain.models.expense.ExpenseCategory
 import com.example.budgetapp.domain.models.expense.Expense
 import com.example.budgetapp.domain.repository_interfaces.IExpenseRepository
@@ -11,6 +12,7 @@ import com.example.budgetapp.utils.formatCurrency
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
@@ -36,14 +38,16 @@ class ExpenseBottomSheetViewModel(
         category: ExpenseCategory,
         description: String,
     ){
-        repository.addExpense(
-            Expense(
-                date = date.atTime(LocalTime.now()),
-                value = if(value > 0.0) -value else value,
-                category = category,
-                description = description
+        viewModelScope.launch {
+            repository.addExpense(
+                Expense(
+                    date = date.atTime(LocalTime.now()),
+                    value = if (value > 0.0) -value else value,
+                    category = category,
+                    description = description
+                )
             )
-        )
+        }
     }
 
     fun validadeForm(description: String, value: Double): Boolean{

--- a/app/src/main/java/com/example/budgetapp/presentation/viewModels/transactionBottomSheet/FExpenseBottomSheetViewModel.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/viewModels/transactionBottomSheet/FExpenseBottomSheetViewModel.kt
@@ -2,6 +2,7 @@ package com.example.budgetapp.presentation.viewModels.transactionBottomSheet
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.budgetapp.domain.models.expense.ExpenseCategory
 import com.example.budgetapp.domain.models.expense.FixedExpense
 import com.example.budgetapp.domain.repository_interfaces.IFixedExpenseRepository
@@ -11,6 +12,7 @@ import com.example.budgetapp.utils.formatCurrency
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
@@ -53,12 +55,16 @@ class FExpenseBottomSheetViewModel(
         category: ExpenseCategory,
         description: String,
     ){
-        repository.addFixedExpense(FixedExpense(
-            date = date.atTime(LocalTime.now()),
-            value = if(value > 0.0) -value else value,
-            category = category,
-            description = description
-        ))
+        viewModelScope.launch {
+            repository.addFixedExpense(
+                FixedExpense(
+                    date = date.atTime(LocalTime.now()),
+                    value = if (value > 0.0) -value else value,
+                    category = category,
+                    description = description
+                )
+            )
+        }
     }
 
     fun clearState(){

--- a/app/src/main/java/com/example/budgetapp/presentation/viewModels/transactionBottomSheet/FIncomeBottomSheetViewModel.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/viewModels/transactionBottomSheet/FIncomeBottomSheetViewModel.kt
@@ -2,6 +2,7 @@ package com.example.budgetapp.presentation.viewModels.transactionBottomSheet
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.budgetapp.domain.models.income.FixedIncome
 import com.example.budgetapp.domain.models.income.IncomeCategory
 import com.example.budgetapp.domain.repository_interfaces.IFixedIncomeRepository
@@ -11,6 +12,7 @@ import com.example.budgetapp.utils.formatCurrency
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
@@ -53,14 +55,16 @@ class FIncomeBottomSheetViewModel(
         category: IncomeCategory,
         description: String,
     ){
-        repository.addFixedIncome(
-            FixedIncome(
-                date = date.atTime(LocalTime.now()),
-                value = if(value < 0.0) +value else value,
-                category = category,
-                description = description
+        viewModelScope.launch {
+            repository.addFixedIncome(
+                FixedIncome(
+                    date = date.atTime(LocalTime.now()),
+                    value = if (value < 0.0) +value else value,
+                    category = category,
+                    description = description
+                )
             )
-        )
+        }
     }
 
     fun clearState(){

--- a/app/src/main/java/com/example/budgetapp/presentation/viewModels/transactionBottomSheet/IncomeBottomSheetViewModel.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/viewModels/transactionBottomSheet/IncomeBottomSheetViewModel.kt
@@ -2,6 +2,7 @@ package com.example.budgetapp.presentation.viewModels.transactionBottomSheet
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.budgetapp.domain.models.income.IncomeCategory
 import com.example.budgetapp.domain.models.income.Income
 import com.example.budgetapp.domain.repository_interfaces.IIncomeRepository
@@ -11,6 +12,7 @@ import com.example.budgetapp.utils.formatCurrency
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
@@ -36,14 +38,16 @@ class IncomeBottomSheetViewModel(
         category: IncomeCategory,
         description: String,
     ){
-        repository.addIncome(
-            Income(
-                date = date.atTime(LocalTime.now()),
-                value = if(value < 0.0) +value else value,
-                category = category,
-                description = description
+        viewModelScope.launch {
+            repository.addIncome(
+                Income(
+                    date = date.atTime(LocalTime.now()),
+                    value = if (value < 0.0) +value else value,
+                    category = category,
+                    description = description
+                )
             )
-        )
+        }
     }
 
     fun validadeForm(description: String, value: Double): Boolean{

--- a/app/src/main/java/com/example/budgetapp/presentation/views/HomeView.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/views/HomeView.kt
@@ -78,14 +78,14 @@ fun HomeView(
         val scope = rememberCoroutineScope()
 
         LaunchedEffect(key1 = homeUiState) {
-            if(!homeUiState.errorMsg.isNullOrEmpty()) {
+            //if(!homeUiState.errorMsg.isNullOrEmpty()) {
                 scope.launch {
                     snackbarHostState.showSnackbar(
                         "${homeUiState.errorMsg}",
                         duration = SnackbarDuration.Long
                     )
                 }
-            }
+            //}
         }
 
         Surface(

--- a/app/src/main/java/com/example/budgetapp/presentation/views/HomeView.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/views/HomeView.kt
@@ -65,10 +65,6 @@ fun HomeView(
         var isAddFixedIncomeOpen by rememberSaveable { mutableStateOf(false) }
         var isAddFixedExpenseOpen by rememberSaveable { mutableStateOf(false) }
 
-        LaunchedEffect(key1 = Unit) {
-            viewModel.updateAll()
-        }
-
         Surface(
             modifier = modifier
                 .fillMaxSize()
@@ -201,7 +197,6 @@ fun HomeView(
                         isAddExpenseOpen = false
                     },
                     onAdd = {
-                        viewModel.updateAll()
                         isAddExpenseOpen = false
                     },
                     bottomSheetViewModel = expenseBottomSheetViewModel,
@@ -216,7 +211,6 @@ fun HomeView(
                         isAddIncomeOpen = false
                     },
                     onAdd = {
-                        viewModel.updateAll()
                         isAddIncomeOpen = false
                     },
                     bottomSheetViewModel = incomeBottomSheetViewModel
@@ -231,7 +225,6 @@ fun HomeView(
                         isAddFixedExpenseOpen = false
                     },
                     onAdd = {
-                        viewModel.updateAll()
                         isAddFixedExpenseOpen = false
                     },
                     bottomSheetViewModel = fExpenseBottomSheetViewModel
@@ -246,7 +239,6 @@ fun HomeView(
                         isAddFixedIncomeOpen = false
                     },
                     onAdd = {
-                        viewModel.updateAll()
                         isAddFixedIncomeOpen = false
                     },
                     bottomSheetViewModel = fIncomeBottomSheetViewModel

--- a/app/src/main/java/com/example/budgetapp/presentation/views/HomeView.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/views/HomeView.kt
@@ -8,11 +8,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Snackbar
-import androidx.compose.material3.SnackbarData
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -20,7 +15,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -30,14 +24,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.core.content.ContextCompat
 import androidx.navigation.NavHostController
 import com.example.budgetapp.R
 import com.example.budgetapp.domain.models.transaction.FixedTransaction
@@ -60,6 +52,7 @@ import com.example.budgetapp.presentation.views.records.BottomBarScreen
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.KoinContext
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 @Composable
 fun HomeView(
@@ -68,7 +61,7 @@ fun HomeView(
     viewModel: HomeViewModel
 ){
     KoinContext {
-        val homeUiState by viewModel.uiState.collectAsState()
+        val homeUiState by viewModel.uiState.collectAsStateWithLifecycle()
         val snackbarHostState = remember { SnackbarHostState() }
         val expenseBottomSheetViewModel = koinViewModel<ExpenseBottomSheetViewModel>()
         val incomeBottomSheetViewModel = koinViewModel<IncomeBottomSheetViewModel>()

--- a/app/src/main/java/com/example/budgetapp/presentation/views/HomeView.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/views/HomeView.kt
@@ -61,8 +61,10 @@ fun HomeView(
     viewModel: HomeViewModel
 ){
     KoinContext {
+
         val homeUiState by viewModel.uiState.collectAsStateWithLifecycle()
         val snackbarHostState = remember { SnackbarHostState() }
+
         val expenseBottomSheetViewModel = koinViewModel<ExpenseBottomSheetViewModel>()
         val incomeBottomSheetViewModel = koinViewModel<IncomeBottomSheetViewModel>()
         val fExpenseBottomSheetViewModel = koinViewModel<FExpenseBottomSheetViewModel>()
@@ -168,7 +170,7 @@ fun HomeView(
                         incomeBalance = homeUiState.incomeBalance,
                         expenseBalance = homeUiState.expenseBalance,
                         modifier = modifier,
-                        onReloadClicked = { viewModel.updateAll() },
+                        onReloadClicked = { viewModel.refresh() },
                         isLoading = homeUiState.isLoading
                     )
                 }

--- a/app/src/main/java/com/example/budgetapp/presentation/views/MainActivity.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/views/MainActivity.kt
@@ -16,7 +16,9 @@ import com.example.budgetapp.domain.modules.FixedExpenseBottomSheetModule
 import com.example.budgetapp.domain.modules.FixedIncomeBottomSheetModule
 import com.example.budgetapp.domain.modules.IncomeBottomSheetModule
 import com.example.budgetapp.domain.modules.RecordsModule
-import com.example.budgetapp.domain.modules.homePageModule
+import com.example.budgetapp.domain.modules.RepositoryModule
+import com.example.budgetapp.domain.modules.DatabaseModule
+import com.example.budgetapp.domain.modules.HomePageModule
 import com.example.budgetapp.presentation.graphs.RootNavigationGraph
 import com.example.budgetapp.presentation.ui.theme.BudgetAppTheme
 import com.example.budgetapp.presentation.viewModels.home.HomeViewModel
@@ -53,12 +55,14 @@ class MainActivity : ComponentActivity() {
             androidLogger()
             androidContext(this@MainActivity)
             modules(
-                homePageModule,
+                HomePageModule,
                 ExpenseBottomSheetModule,
                 IncomeBottomSheetModule,
                 FixedExpenseBottomSheetModule,
                 FixedIncomeBottomSheetModule,
-                RecordsModule
+                RecordsModule,
+                DatabaseModule,
+                RepositoryModule
             )
         }
     }

--- a/app/src/main/java/com/example/budgetapp/presentation/views/records/RecordsExpenses.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/views/records/RecordsExpenses.kt
@@ -166,11 +166,11 @@ fun RecordsExpenses(
                             transactions = fixedTransactions,
                             onDelete = {
                                 viewModel.removeTransaction(it)
-                                viewModel.updateAll()
                             },
                             onNewTransactionClicked = {
                                 isAddFixedExpenseOpen = !isAddFixedExpenseOpen
-                            }
+                            },
+                            isLoading = UiState.isLoading
                         )
                     } else {
                         RecordCard(
@@ -179,9 +179,9 @@ fun RecordsExpenses(
                             transactions = transactions,
                             onDelete = {
                                 viewModel.removeTransaction(it)
-                                viewModel.updateAll()
                             },
-                            onNewTransactionClicked = { isAddExpenseOpen = !isAddExpenseOpen }
+                            onNewTransactionClicked = { isAddExpenseOpen = !isAddExpenseOpen },
+                            isLoading = UiState.isLoading
                         )
                     }
                 }
@@ -194,7 +194,6 @@ fun RecordsExpenses(
                     isAddExpenseOpen = false
                 },
                 onAdd = {
-                    viewModel.updateAll()
                     isAddExpenseOpen = false
                 },
                 bottomSheetViewModel = expenseBottomSheetViewModel,
@@ -209,7 +208,6 @@ fun RecordsExpenses(
                     isAddFixedExpenseOpen = false
                 },
                 onAdd = {
-                    viewModel.updateAll()
                     isAddFixedExpenseOpen = false
                 },
                 bottomSheetViewModel = fExpenseBottomSheetViewModel

--- a/app/src/main/java/com/example/budgetapp/presentation/views/records/RecordsExpenses.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/views/records/RecordsExpenses.kt
@@ -48,7 +48,7 @@ import org.koin.compose.KoinContext
 @Composable
 fun RecordsExpenses(
     modifier: Modifier = Modifier,
-    viewModel: RecordsViewModel = RecordsViewModel(),
+    viewModel: RecordsViewModel,
     isFixed: Boolean = false,
     onReturnClicked: () -> Unit = {}
 ){

--- a/app/src/main/java/com/example/budgetapp/presentation/views/records/RecordsIncomes.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/views/records/RecordsIncomes.kt
@@ -50,7 +50,7 @@ import org.koin.compose.KoinContext
 @Composable
 fun RecordsIncomes(
     modifier: Modifier = Modifier,
-    viewModel: RecordsViewModel = RecordsViewModel(),
+    viewModel: RecordsViewModel,
     isFixed: Boolean = false,
     onReturnClicked: () -> Unit = {}
 ) {

--- a/app/src/main/java/com/example/budgetapp/presentation/views/records/RecordsIncomes.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/views/records/RecordsIncomes.kt
@@ -168,11 +168,11 @@ fun RecordsIncomes(
                             transactions = fixedTransactions,
                             onDelete = {
                                 viewModel.removeTransaction(it)
-                                viewModel.updateAll()
                             },
                             onNewTransactionClicked = {
                                 isAddFixedIncomeOpen = !isAddFixedIncomeOpen
-                            }
+                            },
+                            isLoading = UiState.isLoading
                         )
                     } else {
                         RecordCard(
@@ -181,9 +181,9 @@ fun RecordsIncomes(
                             transactions = transactions,
                             onDelete = {
                                 viewModel.removeTransaction(it)
-                                viewModel.updateAll()
                             },
-                            onNewTransactionClicked = { isAddIncomeOpen = !isAddIncomeOpen }
+                            onNewTransactionClicked = { isAddIncomeOpen = !isAddIncomeOpen },
+                            isLoading = UiState.isLoading
                         )
                     }
                 }
@@ -197,7 +197,6 @@ fun RecordsIncomes(
                     isAddIncomeOpen = false
                 },
                 onAdd = {
-                    viewModel.updateAll()
                     isAddIncomeOpen = false
                 },
                 bottomSheetViewModel = incomeBottomSheetViewModel
@@ -212,7 +211,6 @@ fun RecordsIncomes(
                     isAddFixedIncomeOpen = false
                 },
                 onAdd = {
-                    viewModel.updateAll()
                     isAddFixedIncomeOpen = false
                 },
                 bottomSheetViewModel = fIncomeBottomSheetViewModel

--- a/app/src/main/java/com/example/budgetapp/presentation/views/records/RecordsOverview.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/views/records/RecordsOverview.kt
@@ -168,11 +168,3 @@ fun RecordsOverview(
         }
     }
 }
-/*
-@Preview(showBackground = true)
-@Composable
-fun PreviewRecordsOverview(){
-    BudgetAppTheme {
-        RecordsOverview()
-    }
-}*/

--- a/app/src/main/java/com/example/budgetapp/presentation/views/records/RecordsOverview.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/views/records/RecordsOverview.kt
@@ -148,9 +148,9 @@ fun RecordsOverview(
                         transactions = fixedTransactions,
                         onDelete = {
                             viewModel.removeTransaction(it)
-                            viewModel.updateAll()
                         },
-                        showAdd = false
+                        showAdd = false,
+                        isLoading = UiState.isLoading
                     )
                 } else {
                     RecordCard(
@@ -159,9 +159,9 @@ fun RecordsOverview(
                         transactions = transactions,
                         onDelete = {
                             viewModel.removeTransaction(it)
-                            viewModel.updateAll()
                         },
-                        showAdd = false
+                        showAdd = false,
+                        isLoading = UiState.isLoading
                     )
                 }
             }

--- a/app/src/main/java/com/example/budgetapp/presentation/views/records/RecordsOverview.kt
+++ b/app/src/main/java/com/example/budgetapp/presentation/views/records/RecordsOverview.kt
@@ -39,7 +39,7 @@ import com.example.budgetapp.presentation.viewModels.records.RecordsViewModel
 @Composable
 fun RecordsOverview(
     modifier: Modifier = Modifier,
-    viewModel: RecordsViewModel = RecordsViewModel(),
+    viewModel: RecordsViewModel,
     onReturnClicked: () -> Unit = {}
 ){
     val UiState by viewModel.uiState.collectAsState()
@@ -168,11 +168,11 @@ fun RecordsOverview(
         }
     }
 }
-
+/*
 @Preview(showBackground = true)
 @Composable
 fun PreviewRecordsOverview(){
     BudgetAppTheme {
         RecordsOverview()
     }
-}
+}*/

--- a/app/src/main/java/com/example/budgetapp/services/dao/expense/ExpenseDao.kt
+++ b/app/src/main/java/com/example/budgetapp/services/dao/expense/ExpenseDao.kt
@@ -14,11 +14,12 @@ interface ExpenseDao {
     fun fetchAll(): Flow<List<Expense>>
 
     @Insert
-    fun add(expense: Expense): Long
-
-    @Delete
-    fun remove(expense: Expense): Int
+    suspend fun add(expense: Expense): Long
 
     @Upsert
-    fun update(expense: Expense): Int
+    suspend fun update(expense: Expense): Long
+
+    @Delete
+    suspend fun remove(expense: Expense): Int
+
 }

--- a/app/src/main/java/com/example/budgetapp/services/dao/expense/ExpenseDao.kt
+++ b/app/src/main/java/com/example/budgetapp/services/dao/expense/ExpenseDao.kt
@@ -1,0 +1,24 @@
+package com.example.budgetapp.services.dao.expense
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Upsert
+import com.example.budgetapp.domain.models.expense.Expense
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ExpenseDao {
+    @Query("Select * FROM Expense")
+    fun fetchAll(): Flow<List<Expense>>
+
+    @Insert
+    fun add(expense: Expense): Long
+
+    @Delete
+    fun remove(expense: Expense): Int
+
+    @Upsert
+    fun update(expense: Expense): Int
+}

--- a/app/src/main/java/com/example/budgetapp/services/dao/fixedExpense/FixedExpenseDao.kt
+++ b/app/src/main/java/com/example/budgetapp/services/dao/fixedExpense/FixedExpenseDao.kt
@@ -11,14 +11,14 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface FixedExpenseDao {
     @Query("SELECT * FROM FixedExpense")
-    suspend fun fetchAll(): Flow<List<FixedExpense>>
+    fun fetchAll(): Flow<List<FixedExpense>>
 
     @Insert
     suspend fun add(fixedExpense: FixedExpense): Long
 
     @Upsert
-    suspend fun update(fixedExpense: FixedExpense): Int
+    suspend fun update(fixedExpense: FixedExpense): Long
 
     @Delete
-    suspend fun delete(fixedExpense: FixedExpense): Int
+    suspend fun remove(fixedExpense: FixedExpense): Int
 }

--- a/app/src/main/java/com/example/budgetapp/services/dao/fixedExpense/FixedExpenseDao.kt
+++ b/app/src/main/java/com/example/budgetapp/services/dao/fixedExpense/FixedExpenseDao.kt
@@ -4,6 +4,8 @@ import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Update
 import androidx.room.Upsert
 import com.example.budgetapp.domain.models.expense.FixedExpense
 import kotlinx.coroutines.flow.Flow
@@ -18,6 +20,9 @@ interface FixedExpenseDao {
 
     @Upsert
     suspend fun update(fixedExpense: FixedExpense): Long
+
+    @Update
+    suspend fun update(fixedExpenses: List<FixedExpense>): Int
 
     @Delete
     suspend fun remove(fixedExpense: FixedExpense): Int

--- a/app/src/main/java/com/example/budgetapp/services/dao/fixedExpense/FixedExpenseDao.kt
+++ b/app/src/main/java/com/example/budgetapp/services/dao/fixedExpense/FixedExpenseDao.kt
@@ -1,0 +1,24 @@
+package com.example.budgetapp.services.dao.fixedExpense
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Upsert
+import com.example.budgetapp.domain.models.expense.FixedExpense
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface FixedExpenseDao {
+    @Query("SELECT * FROM FixedExpense")
+    suspend fun fetchAll(): Flow<List<FixedExpense>>
+
+    @Insert
+    suspend fun add(fixedExpense: FixedExpense): Long
+
+    @Upsert
+    suspend fun update(fixedExpense: FixedExpense): Int
+
+    @Delete
+    suspend fun delete(fixedExpense: FixedExpense): Int
+}

--- a/app/src/main/java/com/example/budgetapp/services/dao/fixedIncome/FixedIncomeDao.kt
+++ b/app/src/main/java/com/example/budgetapp/services/dao/fixedIncome/FixedIncomeDao.kt
@@ -1,0 +1,25 @@
+package com.example.budgetapp.services.dao.fixedIncome
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Upsert
+import com.example.budgetapp.domain.models.expense.FixedExpense
+import com.example.budgetapp.domain.models.income.FixedIncome
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface FixedIncomeDao {
+    @Query("SELECT * FROM FixedIncome")
+    suspend fun fetchAll(): Flow<List<FixedIncome>>
+
+    @Insert
+    suspend fun add(fixedIncome: FixedIncome): Long
+
+    @Upsert
+    suspend fun update(fixedIncome: FixedIncome): Int
+
+    @Delete
+    suspend fun delete(fixedIncome: FixedIncome): Int
+}

--- a/app/src/main/java/com/example/budgetapp/services/dao/fixedIncome/FixedIncomeDao.kt
+++ b/app/src/main/java/com/example/budgetapp/services/dao/fixedIncome/FixedIncomeDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Update
 import androidx.room.Upsert
 import com.example.budgetapp.domain.models.expense.FixedExpense
 import com.example.budgetapp.domain.models.income.FixedIncome
@@ -19,6 +20,9 @@ interface FixedIncomeDao {
 
     @Upsert
     suspend fun update(fixedIncome: FixedIncome): Long
+
+    @Update
+    suspend fun update(fixedIncomes: List<FixedIncome>): Int
 
     @Delete
     suspend fun remove(fixedIncome: FixedIncome): Int

--- a/app/src/main/java/com/example/budgetapp/services/dao/fixedIncome/FixedIncomeDao.kt
+++ b/app/src/main/java/com/example/budgetapp/services/dao/fixedIncome/FixedIncomeDao.kt
@@ -12,14 +12,14 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface FixedIncomeDao {
     @Query("SELECT * FROM FixedIncome")
-    suspend fun fetchAll(): Flow<List<FixedIncome>>
+    fun fetchAll(): Flow<List<FixedIncome>>
 
     @Insert
     suspend fun add(fixedIncome: FixedIncome): Long
 
     @Upsert
-    suspend fun update(fixedIncome: FixedIncome): Int
+    suspend fun update(fixedIncome: FixedIncome): Long
 
     @Delete
-    suspend fun delete(fixedIncome: FixedIncome): Int
+    suspend fun remove(fixedIncome: FixedIncome): Int
 }

--- a/app/src/main/java/com/example/budgetapp/services/dao/income/IncomeDao.kt
+++ b/app/src/main/java/com/example/budgetapp/services/dao/income/IncomeDao.kt
@@ -11,14 +11,15 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface IncomeDao {
     @Query("Select * FROM Income")
-    suspend fun fetchAll(): Flow<List<Income>>
+    fun fetchAll(): Flow<List<Income>>
 
     @Insert
     suspend fun add(income: Income): Long
 
+    @Upsert
+    suspend fun update(income: Income): Long
+
     @Delete
     suspend fun remove(income: Income): Int
 
-    @Upsert
-    suspend fun update(income: Income): Int
 }

--- a/app/src/main/java/com/example/budgetapp/services/dao/income/IncomeDao.kt
+++ b/app/src/main/java/com/example/budgetapp/services/dao/income/IncomeDao.kt
@@ -1,0 +1,24 @@
+package com.example.budgetapp.services.dao.income
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Upsert
+import com.example.budgetapp.domain.models.income.Income
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface IncomeDao {
+    @Query("Select * FROM Income")
+    suspend fun fetchAll(): Flow<List<Income>>
+
+    @Insert
+    suspend fun add(income: Income): Long
+
+    @Delete
+    suspend fun remove(income: Income): Int
+
+    @Upsert
+    suspend fun update(income: Income): Int
+}

--- a/app/src/main/java/com/example/budgetapp/services/database/AppDatabase.kt
+++ b/app/src/main/java/com/example/budgetapp/services/database/AppDatabase.kt
@@ -14,7 +14,7 @@ import com.example.budgetapp.services.dao.income.IncomeDao
 
 @Database(
     entities = [Income::class, Expense::class, FixedExpense::class, FixedIncome::class],
-    version = 3,
+    version = 4,
     exportSchema = false
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/example/budgetapp/services/database/AppDatabase.kt
+++ b/app/src/main/java/com/example/budgetapp/services/database/AppDatabase.kt
@@ -1,0 +1,26 @@
+package com.example.budgetapp.services.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.example.budgetapp.domain.models.expense.Expense
+import com.example.budgetapp.domain.models.income.Income
+import com.example.budgetapp.services.dao.fixedIncome.FixedIncomeDao
+import com.example.budgetapp.services.dao.expense.ExpenseDao
+import com.example.budgetapp.services.dao.fixedExpense.FixedExpenseDao
+import com.example.budgetapp.services.dao.income.IncomeDao
+
+@Database(
+    entities = [Income::class, Expense::class],
+    version = 1,
+    exportSchema = false
+)
+@TypeConverters(Converters::class)
+abstract class AppDatabase: RoomDatabase() {
+    abstract fun incomeDao(): IncomeDao
+    abstract fun expenseDao(): ExpenseDao
+
+    abstract fun fixedExpenseDao(): FixedExpenseDao
+
+    abstract fun fixedIncomeDao(): FixedIncomeDao
+}

--- a/app/src/main/java/com/example/budgetapp/services/database/AppDatabase.kt
+++ b/app/src/main/java/com/example/budgetapp/services/database/AppDatabase.kt
@@ -4,6 +4,8 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.example.budgetapp.domain.models.expense.Expense
+import com.example.budgetapp.domain.models.expense.FixedExpense
+import com.example.budgetapp.domain.models.income.FixedIncome
 import com.example.budgetapp.domain.models.income.Income
 import com.example.budgetapp.services.dao.fixedIncome.FixedIncomeDao
 import com.example.budgetapp.services.dao.expense.ExpenseDao
@@ -11,8 +13,8 @@ import com.example.budgetapp.services.dao.fixedExpense.FixedExpenseDao
 import com.example.budgetapp.services.dao.income.IncomeDao
 
 @Database(
-    entities = [Income::class, Expense::class],
-    version = 1,
+    entities = [Income::class, Expense::class, FixedExpense::class, FixedIncome::class],
+    version = 3,
     exportSchema = false
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/example/budgetapp/services/database/AppDatabase.kt
+++ b/app/src/main/java/com/example/budgetapp/services/database/AppDatabase.kt
@@ -14,7 +14,7 @@ import com.example.budgetapp.services.dao.income.IncomeDao
 
 @Database(
     entities = [Income::class, Expense::class, FixedExpense::class, FixedIncome::class],
-    version = 4,
+    version = 5,
     exportSchema = false
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/example/budgetapp/services/database/Converters.kt
+++ b/app/src/main/java/com/example/budgetapp/services/database/Converters.kt
@@ -1,0 +1,63 @@
+package com.example.budgetapp.services.database
+
+import androidx.room.TypeConverter
+import com.example.budgetapp.domain.models.expense.ExpenseCategory
+import com.example.budgetapp.domain.models.income.IncomeCategory
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+class Converters {
+
+    @TypeConverter
+    fun dateTimeFromTimestamp(value: String): LocalDateTime{
+        return value.let { LocalDateTime.parse(it, DateTimeFormatter.ISO_LOCAL_DATE_TIME) }
+    }
+
+    @TypeConverter
+    fun dateTimeToTimestamp(value: LocalDateTime): String{
+        return value.let { it.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) }
+    }
+
+    @TypeConverter
+    fun dateFromTimestamp(value: String?): LocalDate?{
+        return value?.let { LocalDate.parse(it, DateTimeFormatter.ISO_LOCAL_DATE) }
+    }
+
+    @TypeConverter
+    fun dateToTimestamp(value: LocalDate?): String?{
+        return value?.let { it.format(DateTimeFormatter.ISO_LOCAL_DATE) }
+    }
+
+    @TypeConverter
+    fun toExpenseCategory(value: Int): ExpenseCategory{
+        return value.let { enumValues<ExpenseCategory>()[it] }
+    }
+
+    @TypeConverter
+    fun fromExpenseCategory(value: ExpenseCategory): Int{
+        return value.let { it.ordinal }
+    }
+
+    @TypeConverter
+    fun toIncomeCategory(value: Int): IncomeCategory {
+        return value.let { enumValues<IncomeCategory>()[it] }
+    }
+
+    @TypeConverter
+    fun fromIncomeCategory(value: IncomeCategory): Int{
+        return value.let { it.ordinal }
+    }
+
+    @TypeConverter
+    fun fromUUID(value: UUID): String{
+        return value.let { it.toString() }
+    }
+
+    @TypeConverter
+    fun toUUID(value: String): UUID{
+        return value.let { UUID.fromString(it) }
+    }
+
+}

--- a/app/src/main/java/com/example/budgetapp/services/repository/expense/LocalExpenseRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/services/repository/expense/LocalExpenseRepository.kt
@@ -1,82 +1,27 @@
 package com.example.budgetapp.services.repository.expense
 
-import com.example.budgetapp.domain.models.expense.ExpenseCategory
 import com.example.budgetapp.domain.repository_interfaces.IExpenseRepository
 import com.example.budgetapp.domain.models.expense.Expense
-import java.time.LocalDateTime
+import com.example.budgetapp.services.dao.expense.ExpenseDao
+import kotlinx.coroutines.flow.Flow
 
-object LocalExpenseRepository: IExpenseRepository {
-    private val expenses: MutableList<Expense> = mutableListOf(
-        Expense(
-            date = LocalDateTime.parse("2024-06-06T10:30:00"),
-            value = -50.00,
-            category = ExpenseCategory.FUEL,
-            description = "Gasolina Fox"
-        ),
-        Expense(
-            date = LocalDateTime.parse("2024-06-01T11:30:00"),
-            value = -25.00,
-            category = ExpenseCategory.RESTAURANT,
-            description = "Almoço"
-        ),
-        Expense(
-            date = LocalDateTime.parse("2024-06-02T08:30:00"),
-            value = -5.00,
-            category = ExpenseCategory.RESTAURANT,
-            description = "Café"
-        ),
-        Expense(
-            date = LocalDateTime.parse("2024-06-02T08:30:00"),
-            value = -105.00,
-            category = ExpenseCategory.LIGHTING,
-            description = "Conta Luz"
-        ),
-        Expense(
-            date = LocalDateTime.parse("2024-06-02T08:30:00"),
-            value = -105.00,
-            category = ExpenseCategory.LIGHTING,
-            description = "Conta Luz"
-        ),
-        Expense(
-            date = LocalDateTime.parse("2024-06-02T08:30:00"),
-            value = -105.00,
-            category = ExpenseCategory.LIGHTING,
-            description = "Conta Luz"
-        ),
-        Expense(
-            date = LocalDateTime.parse("2024-06-02T08:30:00"),
-            value = -105.00,
-            category = ExpenseCategory.LIGHTING,
-            description = "Conta Luz"
-        ),
-        Expense(
-            date = LocalDateTime.parse("2024-06-02T08:30:00"),
-            value = -105.00,
-            category = ExpenseCategory.LIGHTING,
-            description = "Conta Luz"
-        ),
-        Expense(
-            date = LocalDateTime.parse("2024-06-02T08:30:00"),
-            value = -105.00,
-            category = ExpenseCategory.LIGHTING,
-            description = "Conta Luz"
-        ),
-    )
-    override fun fetchAll(): MutableList<Expense> {
-        return expenses
+class LocalExpenseRepository(
+    private val dao: ExpenseDao
+): IExpenseRepository {
+
+    override suspend fun fetchAll(): Flow<List<Expense>> {
+        return dao.fetchAll()
     }
 
-    override fun addExpense(expense: Expense) {
-        expenses.add(expense)
+    override suspend fun addExpense(expense: Expense): Long {
+        return dao.add(expense)
     }
 
-    override fun removeExpense(expense: Expense) {
-        expenses.remove(expense)
+    override suspend fun removeExpense(expense: Expense): Int {
+        return dao.remove(expense)
     }
 
-    override fun updateExpense(expense: Expense) {
-        if(expenses.removeIf { it.id.compareTo(expense.id) == 0 }){
-            expenses.add(expense)
-        }
+    override suspend fun updateExpense(expense: Expense): Int {
+        return dao.update(expense)
     }
 }

--- a/app/src/main/java/com/example/budgetapp/services/repository/expense/LocalExpenseRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/services/repository/expense/LocalExpenseRepository.kt
@@ -9,7 +9,7 @@ class LocalExpenseRepository(
     private val dao: ExpenseDao
 ): IExpenseRepository {
 
-    override suspend fun fetchAll(): Flow<List<Expense>> {
+    override fun fetchAll(): Flow<List<Expense>> {
         return dao.fetchAll()
     }
 
@@ -21,7 +21,7 @@ class LocalExpenseRepository(
         return dao.remove(expense)
     }
 
-    override suspend fun updateExpense(expense: Expense): Int {
+    override suspend fun updateExpense(expense: Expense): Long {
         return dao.update(expense)
     }
 }

--- a/app/src/main/java/com/example/budgetapp/services/repository/fixed_expense/LocalFixedExpenseRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/services/repository/fixed_expense/LocalFixedExpenseRepository.kt
@@ -25,4 +25,8 @@ class LocalFixedExpenseRepository(
     override suspend fun updateFixedExpense(fixedExpense: FixedExpense): Long {
         return dao.update(fixedExpense)
     }
+
+    override suspend fun updateFixedExpense(fixedExpenses: List<FixedExpense>): Int {
+        return dao.update(fixedExpenses)
+    }
 }

--- a/app/src/main/java/com/example/budgetapp/services/repository/fixed_expense/LocalFixedExpenseRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/services/repository/fixed_expense/LocalFixedExpenseRepository.kt
@@ -10,7 +10,7 @@ class LocalFixedExpenseRepository(
     private val dao: FixedExpenseDao
 ): IFixedExpenseRepository {
 
-    override suspend fun fetchAll(): Flow<List<FixedExpense>> {
+    override fun fetchAll(): Flow<List<FixedExpense>> {
         return dao.fetchAll()
     }
 
@@ -19,10 +19,10 @@ class LocalFixedExpenseRepository(
     }
 
     override suspend fun removeFixedExpense(fixedExpense: FixedExpense): Int {
-        return dao.delete(fixedExpense)
+        return dao.remove(fixedExpense)
     }
 
-    override suspend fun updateFixedExpense(fixedExpense: FixedExpense): Int {
+    override suspend fun updateFixedExpense(fixedExpense: FixedExpense): Long {
         return dao.update(fixedExpense)
     }
 }

--- a/app/src/main/java/com/example/budgetapp/services/repository/fixed_expense/LocalFixedExpenseRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/services/repository/fixed_expense/LocalFixedExpenseRepository.kt
@@ -2,26 +2,27 @@ package com.example.budgetapp.services.repository.fixed_expense
 
 import com.example.budgetapp.domain.repository_interfaces.IFixedExpenseRepository
 import com.example.budgetapp.domain.models.expense.FixedExpense
+import com.example.budgetapp.services.dao.fixedExpense.FixedExpenseDao
+import kotlinx.coroutines.flow.Flow
 
-object LocalFixedExpenseRepository: IFixedExpenseRepository {
 
-    private val fixedExpenses: MutableList<FixedExpense> = mutableListOf()
+class LocalFixedExpenseRepository(
+    private val dao: FixedExpenseDao
+): IFixedExpenseRepository {
 
-    override fun fetchAll(): MutableList<FixedExpense> {
-        return fixedExpenses
+    override suspend fun fetchAll(): Flow<List<FixedExpense>> {
+        return dao.fetchAll()
     }
 
-    override fun addFixedExpense(fixedExpense: FixedExpense) {
-        fixedExpenses.add(fixedExpense)
+    override suspend fun addFixedExpense(fixedExpense: FixedExpense): Long {
+        return dao.add(fixedExpense)
     }
 
-    override fun removeFixedExpense(fixedExpense: FixedExpense) {
-        fixedExpenses.remove(fixedExpense)
+    override suspend fun removeFixedExpense(fixedExpense: FixedExpense): Int {
+        return dao.delete(fixedExpense)
     }
 
-    override fun updateFixedExpense(fixedExpense: FixedExpense) {
-        if (fixedExpenses.removeIf { it.id.compareTo(fixedExpense.id) == 0 }){
-            fixedExpenses.add(fixedExpense)
-        }
+    override suspend fun updateFixedExpense(fixedExpense: FixedExpense): Int {
+        return dao.update(fixedExpense)
     }
 }

--- a/app/src/main/java/com/example/budgetapp/services/repository/fixed_income/LocalFixedIncomeRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/services/repository/fixed_income/LocalFixedIncomeRepository.kt
@@ -27,4 +27,8 @@ class LocalFixedIncomeRepository(
     override suspend fun updateFixedIncome(fixedIncome: FixedIncome): Long {
         return dao.update(fixedIncome)
     }
+
+    override suspend fun updateFixedIncome(fixedIncomes: List<FixedIncome>): Int {
+        return dao.update(fixedIncomes)
+    }
 }

--- a/app/src/main/java/com/example/budgetapp/services/repository/fixed_income/LocalFixedIncomeRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/services/repository/fixed_income/LocalFixedIncomeRepository.kt
@@ -4,34 +4,27 @@ import android.util.Log
 import com.example.budgetapp.domain.repository_interfaces.IFixedIncomeRepository
 import com.example.budgetapp.domain.models.income.FixedIncome
 import com.example.budgetapp.domain.models.income.IncomeCategory
+import com.example.budgetapp.services.dao.fixedIncome.FixedIncomeDao
+import kotlinx.coroutines.flow.Flow
 import java.time.LocalDateTime
 
-object LocalFixedIncomeRepository: IFixedIncomeRepository {
+class LocalFixedIncomeRepository(
+    private val dao: FixedIncomeDao
+): IFixedIncomeRepository {
 
-    private val fixedIncomes: MutableList<FixedIncome> = mutableListOf(
-        FixedIncome(
-            date = LocalDateTime.parse("2024-06-03T10:00:00"),
-            value = 1415.00,
-            category = IncomeCategory.SALARY,
-            description = "Salário",
-        )
-    )
-
-    override fun fetchAll(): MutableList<FixedIncome> {
-        return fixedIncomes
+    override suspend fun fetchAll(): Flow<List<FixedIncome>> {
+        return dao.fetchAll()
     }
 
-    override fun addFixedIncome(fixedIncome: FixedIncome) {
-        fixedIncomes.add(fixedIncome)
+    override suspend fun addFixedIncome(fixedIncome: FixedIncome): Long {
+        return dao.add(fixedIncome)
     }
 
-    override fun removeFixedIncome(fixedIncome: FixedIncome) {
-        fixedIncomes.remove(fixedIncome)
+    override suspend fun removeFixedIncome(fixedIncome: FixedIncome): Int {
+        return dao.delete(fixedIncome)
     }
 
-    override fun updateFixedIncome(fixedIncome: FixedIncome) {
-        if(fixedIncomes.removeIf({it.id.compareTo(fixedIncome.id) == 0})){
-            fixedIncomes.add(fixedIncome)
-        }
+    override suspend fun updateFixedIncome(fixedIncome: FixedIncome): Int {
+        return dao.update(fixedIncome)
     }
 }

--- a/app/src/main/java/com/example/budgetapp/services/repository/fixed_income/LocalFixedIncomeRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/services/repository/fixed_income/LocalFixedIncomeRepository.kt
@@ -12,7 +12,7 @@ class LocalFixedIncomeRepository(
     private val dao: FixedIncomeDao
 ): IFixedIncomeRepository {
 
-    override suspend fun fetchAll(): Flow<List<FixedIncome>> {
+    override fun fetchAll(): Flow<List<FixedIncome>> {
         return dao.fetchAll()
     }
 
@@ -21,10 +21,10 @@ class LocalFixedIncomeRepository(
     }
 
     override suspend fun removeFixedIncome(fixedIncome: FixedIncome): Int {
-        return dao.delete(fixedIncome)
+        return dao.remove(fixedIncome)
     }
 
-    override suspend fun updateFixedIncome(fixedIncome: FixedIncome): Int {
+    override suspend fun updateFixedIncome(fixedIncome: FixedIncome): Long {
         return dao.update(fixedIncome)
     }
 }

--- a/app/src/main/java/com/example/budgetapp/services/repository/income/LocalIncomeRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/services/repository/income/LocalIncomeRepository.kt
@@ -11,7 +11,7 @@ class LocalIncomeRepository(
     private val dao: IncomeDao
 ): IIncomeRepository {
 
-    override suspend fun fetchAll(): Flow<List<Income>> {
+    override fun fetchAll(): Flow<List<Income>> {
         return dao.fetchAll()
     }
 
@@ -23,7 +23,7 @@ class LocalIncomeRepository(
         return dao.remove(income)
     }
 
-    override suspend fun updateIncome(income: Income): Int {
+    override suspend fun updateIncome(income: Income): Long {
         return dao.update(income)
     }
 }

--- a/app/src/main/java/com/example/budgetapp/services/repository/income/LocalIncomeRepository.kt
+++ b/app/src/main/java/com/example/budgetapp/services/repository/income/LocalIncomeRepository.kt
@@ -3,46 +3,27 @@ package com.example.budgetapp.services.repository.income
 import com.example.budgetapp.domain.models.income.IncomeCategory
 import com.example.budgetapp.domain.repository_interfaces.IIncomeRepository
 import com.example.budgetapp.domain.models.income.Income
+import com.example.budgetapp.services.dao.income.IncomeDao
+import kotlinx.coroutines.flow.Flow
 import java.time.LocalDateTime
 
-object LocalIncomeRepository: IIncomeRepository {
+class LocalIncomeRepository(
+    private val dao: IncomeDao
+): IIncomeRepository {
 
-    private val incomes: MutableList<Income> = mutableListOf(
-        Income(
-            date = LocalDateTime.parse("2024-04-30T10:30:00"),
-            value = 1415.00,
-            category = IncomeCategory.SALARY,
-            description = "Salário"
-        ),
-        Income(
-            date = LocalDateTime.parse("2024-05-31T10:30:00"),
-            value = 1415.00,
-            category = IncomeCategory.SALARY,
-            description = "Salário"
-        ),
-        Income(
-            date = LocalDateTime.parse("2024-05-31T08:30:00"),
-            value = 1300.00,
-            category = IncomeCategory.SELL,
-            description = "Venda Computador"
-        ),
-    )
-
-    override fun fetchAll(): MutableList<Income> {
-        return incomes
+    override suspend fun fetchAll(): Flow<List<Income>> {
+        return dao.fetchAll()
     }
 
-    override fun addIncome(income: Income) {
-        incomes.add(income)
+    override suspend fun addIncome(income: Income): Long {
+        return dao.add(income)
     }
 
-    override fun removeIncome(income: Income) {
-        incomes.remove(income)
+    override suspend fun removeIncome(income: Income): Int {
+        return dao.remove(income)
     }
 
-    override fun updateIncome(income: Income) {
-        if(incomes.removeIf { it.id.compareTo(income.id) == 0}){
-            incomes.add(income)
-        }
+    override suspend fun updateIncome(income: Income): Int {
+        return dao.update(income)
     }
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,47 +1,70 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="greetings">Hi, %1$s!</string>
+    <string name="app_name" translatable="false">BudgetApp</string>
+    //HomeView
+    <string name="greetings">Hello, %1$s!</string>
     <string name="expenses">Expenses</string>
     <string name="expense">Expense</string>
-    <string name="incomes">Incomes</string>
-    <string name="income">Income</string>
+    <string name="incomes">Revenues</string>
+    <string name="income">Revenue</string>
     <string name="fixed_expenses">Fixed Expenses</string>
     <string name="fixed_expense">Fixed Expense</string>
-    <string name="fixed_incomes">Fixed Incomes</string>
-    <string name="fixed_income">Fixed Income</string>
-    <string name="records">Records</string>
+    <string name="fixed_incomes">Fixed Revenues</string>
+    <string name="fixed_income">Fixed Revenue</string>
+
+    //Records
+    <string name="records">Reports</string>
     <string name="overview">Overview</string>
-    <string name="nothing_found">Nothing found, try adding a new entry.</string>
-    <string name="see_more">See more</string>
+
+    //TransactionCard
+    <string name="nothing_found">Nothing found, try adding a new transaction.</string>
+    <string name="see_more">View more</string>
     <string name="cd_expand_card">Expand Card</string>
     <string name="cd_add_transaction">Add %1$s</string>
-    <string name="header_total">"Total: "</string>
-    <string name="today">Today</string>
-    <string name="default_option">Select an option</string>
-    <string name="variable">Variable</string>
-    <string name="fixed">Fixed</string>
-    <string name="balance">Balance</string>
-    <string name="cd_update">Update</string>
-    <string name="field_category">Category</string>
-    <string name="field_description">Description</string>
-    <string name="field_date">Date</string>
-    <string name="field_value">Amount</string>
-    <string name="cd_clear_field">Clear Field</string>
-    <string name="btn_confirm">Confirm</string>
-    <string name="btn_cancel">Cancel</string>
-    <string name="btn_add">Add</string>
+    
+    //TransactionRecords
     <array name="records_drop_menu_options">
         <item>Month</item>
         <item>Category</item>
     </array>
+
+    //TransactionDateHeader
+    <string name="header_total">Total:</string>
+    <string name="today">Today</string>
+    
+    //DropMenu
+    <string name="default_option">select an option</string>
+    
+    //DoubleSwitch
+    <string name="variable">Variable</string>
+    <string name="fixed">Fixed</string>
+
+    //CardSaldo
+    <string name="balance">Balance</string>
+    <string name="cd_update">Update</string>
+
+    //BottomSheet
+    <string name="field_category">Category</string>
+    <string name="field_description">Description</string>
+    <string name="field_date">Date</string>
+    <string name="field_value">Value</string>
+    <string name="cd_clear_field">Clear Field</string>
+
+    //Buttons
+    <string name="btn_confirm">Confirm</string>
+    <string name="btn_cancel">Cancel</string>
+    <string name="btn_add">Add</string>
+
+    //IncomeCategory
     <string name="commission">Commission</string>
     <string name="gift">Gift</string>
     <string name="interest">Interest</string>
     <string name="investment">Investment</string>
     <string name="salary">Salary</string>
-    <string name="sell">Sell</string>
-    <string name="tips">Tip</string>
+    <string name="sell">Sale</string>
+    <string name="tips">Tips</string>
     <string name="other">Others</string>
+
+    //ExpenseCategory
     <string name="food">Food</string>
     <string name="grocery">Grocery</string>
     <string name="health">Health</string>
@@ -54,7 +77,9 @@
     <string name="fuel">Fuel</string>
     <string name="streaming">Streaming</string>
     <string name="internet">Internet</string>
-    <string name="phone_plan">Phone Plan</string>
+    <string name="phone_plan">Cellular Plan</string>
     <string name="insurance">Insurance</string>
     <string name="installment">Installment</string>
+
+
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
+    id("com.google.devtools.ksp") version "1.9.0-1.0.12" apply false
 }


### PR DESCRIPTION
O que foi feito?

> Implementação da persistência dos dados do usuários como, gastos, entradas, gastos fixos e entradas fixas, localmente utilizando a biblioteca Room DB. Os dados são consumidos como Flow no viewModel, que reage a alterações no banco de dados e atualiza o estado da interface. Também foi incluído estados de carregamento e erro para a tela principal e de relatórios, com efeito _shimmer_ de carregamento e snackbar para mensagens de erro.

Adicionar link da Task

> [PSQP-2406]

Impacto

> Médio

<img src="https://github.com/Ranpu123/BudgetApp/assets/42806632/4db36a9e-5eca-40f2-ac9f-098257b927f9" width=50% height=50%>
<img src="https://github.com/Ranpu123/BudgetApp/assets/42806632/2aafa3a6-9279-482f-8bf2-c8f2b579c99b" width=50% height=50%>
<img src="https://github.com/Ranpu123/BudgetApp/assets/42806632/c70b8b96-1ab7-4913-b368-6090dbfa961d" width=50% height=50%>
